### PR TITLE
Waric was lying to players about the reagents required to summon snakes.

### DIFF
--- a/world/map/conf/magic.conf.template
+++ b/world/map/conf/magic.conf.template
@@ -745,7 +745,7 @@ LOCAL SPELL summon-snakes : "#D11" =
           REQUIRE skill(caster, MAGIC) > level,
           REQUIRE skill(caster, school) > level,
           REQUIRE (script_int(caster, "OrumQuest") > 40),
-          COMPONENTS ["Root", "SnakeEgg"])
+          COMPONENTS ["DarkCrystal", "SnakeEgg"])
       => EFFECT CALL adjust_spellpower(school);
                 CALL default_effect();
                 CALL gain_xp(3, 31);


### PR DESCRIPTION
Magic has been adapted to match Waric's script
Root -> DarkCrystal
