### PR TITLE
Remove quotes around unspoken text.

### DIFF
--- a/world/map/npc/031-1/angelaOutside.txt
+++ b/world/map/npc/031-1/angelaOutside.txt
@@ -48,9 +48,9 @@ L_Whining:
     next;
     mes "\"Oh, when I think what might happen to her right now!\"";
     next;
-    mes "\"She is crying and sobbing.\"";
+    mes "She is crying and sobbing.";
     next;
-    mes "\"It seems she is too upset to tell you anything helpful. If she would just calm down and concentrate a bit...\"";
+    mes "It seems she is too upset to tell you anything helpful. If she would just calm down and concentrate a bit...";
     goto L_Close;
 
 L_Menu_Potion:


### PR DESCRIPTION
What it says on the can. These two lines shouldn't be wrapped in quotes.
