### PR TITLE
Luvia mob skill: prevent infinite slave spawn:

### DIFF
--- a/world/map/db/mob_skill_db.txt
+++ b/world/map/db/mob_skill_db.txt
@@ -67,10 +67,10 @@
 1086,FeyElement@NPC_SUMMONSLAVE_earthscorpionX1,any,198,1,5000,100,500,no,self,slavelt,6,1084,0,0,0,0,
 
 // Luvia skills
-// Splash attack + 7-8 permanent demonic spirits + 1 witch guard every 75s + 1 demonic spirit every 20s
-1102,Luvia@NPC_SUMMONSLAVE_witchguardX1,any,198,1,10000,1000,60000,no,self,always,0,1103,0,0,0,0,
+// 7-8 permanent demonic spirits + 1 witch guard every 75s + 1 demonic spirit every 20s
+1102,Luvia@NPC_SUMMONSLAVE_witchguardX1,any,198,1,10000,1000,60000,no,self,slavelt,32,1103,0,0,0,0,
 1102,Luvia@NPC_SUMMONSLAVE_demonicspiritX2,any,198,2,10000,10,5000,no,self,slavelt,7,1101,0,0,0,0,
-1102,Luvia@NPC_SUMMONSLAVE_demonicspiritX1,any,198,1,10000,10,20000,no,self,always,0,1101,0,0,0,0,
+1102,Luvia@NPC_SUMMONSLAVE_demonicspiritX1,any,198,1,10000,10,20000,no,self,slavelt,64,1101,0,0,0,0,
 
 //The Dread Pirate Marley Skills
 1122,TheDreadPirateMarley@NPC_SUMMONSLAVE,any,198,2,8000,1000,5000,no,self,slavelt,1,1123,0,0,0,0,


### PR DESCRIPTION
  Add a high cap for the Witch Guard and Demonic Spirit spawned regularly.

This is to prevent a forgotten manually spawned Luvia which would endlessly spawn mobs.
