### PR TITLE
switch dock npc sprite

### DIFF
--- a/world/map/npc/008-1/dock.txt
+++ b/world/map/npc/008-1/dock.txt
@@ -12,7 +12,7 @@
     close;
 }
 
-008-1.gat,120,44,0|script|#HurnscaldDock|45,
+008-1.gat,120,44,0|script|#HurnscaldDock|127,
 {
     end;
 OnCommandArrive:

--- a/world/map/npc/022-1/dock.txt
+++ b/world/map/npc/022-1/dock.txt
@@ -20,7 +20,7 @@
     close;
 }
 
-022-1.gat,80,62,0|script|#Tulimshar SouthDock|45,
+022-1.gat,80,62,0|script|#Tulimshar SouthDock|127,
 {
     end;
 OnCommandArrive:
@@ -38,7 +38,7 @@ OnCommandWarp:
     close;
 }
 
-022-1.gat,65,25,0|script|#Tulimshar NorthDock|45,
+022-1.gat,65,25,0|script|#Tulimshar NorthDock|127,
 {
     end;
 OnCommandArrive:

--- a/world/map/npc/029-1/dock.txt
+++ b/world/map/npc/029-1/dock.txt
@@ -13,7 +13,7 @@
     close;
 }
 
-029-1.gat,22,37,0|script|#CandorDock|45,
+029-1.gat,22,37,0|script|#CandorDock|127,
 {
     end;
 OnCommandArrive:

--- a/world/map/npc/031-1/dock.txt
+++ b/world/map/npc/031-1/dock.txt
@@ -13,7 +13,7 @@
     close;
 }
 
-031-1.gat,100,100,0|script|#NivalisDock|45,
+031-1.gat,100,100,0|script|#NivalisDock|127,
 {
     end;
 


### PR DESCRIPTION
This patch removes the [awkward red tile](http://i.imgur.com/o6R4XOP.jpg) near each docks (sprite 45) and replace them with a transparent tile (sprite 127)
