### PR TITLE
Fixed Luvia skill description

### DIFF
--- a/world/map/db/mob_skill_db.txt
+++ b/world/map/db/mob_skill_db.txt
@@ -67,7 +67,7 @@
 1086,FeyElement@NPC_SUMMONSLAVE_earthscorpionX1,any,198,1,5000,100,500,no,self,slavelt,6,1084,0,0,0,0,
 
 // Luvia skills
-// 7-8 permanent demonic spirits + 1 witch guard every 75s + 1 demonic spirit every 20s
+// 7-8 permanent demonic spirits + 1 witch guard every 60s + 1 demonic spirit every 20s
 1102,Luvia@NPC_SUMMONSLAVE_witchguardX1,any,198,1,10000,1000,60000,no,self,slavelt,32,1103,0,0,0,0,
 1102,Luvia@NPC_SUMMONSLAVE_demonicspiritX2,any,198,2,10000,10,5000,no,self,slavelt,7,1101,0,0,0,0,
 1102,Luvia@NPC_SUMMONSLAVE_demonicspiritX1,any,198,1,10000,10,20000,no,self,slavelt,64,1101,0,0,0,0,


### PR DESCRIPTION
Just a very minor fix: the description for Luvia's skills said a Witch Guard is spawned every 75 seconds, but it's actually every 60 seconds. Only a description fix, the skill itself wasn't changed.
