### PR TITLE
Increasing respawn time for Terranites

### DIFF
--- a/world/map/npc/043-4/_mobs.txt
+++ b/world/map/npc/043-4/_mobs.txt
@@ -1,7 +1,7 @@
 // This file is generated automatically. All manually changes will be removed when running the Converter.
 // Sandy Dungeon Level 2 mobs
 
-043-4.gat,139,163,7,6|monster|Terranite|1062,2,200000,100000,Mob043-4::On1062
+043-4.gat,139,163,7,6|monster|Terranite|1062,2,240000,120000,Mob043-4::On1062
 043-4.gat,133,45,14,16|monster|UndeadTroll|1117,4,100000,50000,Mob043-4::On1117
 043-4.gat,91,139,11,10|monster|UndeadTroll|1117,2,100000,50000,Mob043-4::On1117
 043-4.gat,35,120,10,11|monster|UndeadTroll|1117,2,100000,50000,Mob043-4::On1117


### PR DESCRIPTION
...because Terranites in the Troll Cave were meant to be an alternative to the PvP Terranite Cave and not as main grinding point. The respawn time was still a bit too fast therefore.
