### PR TITLE
Changing mob spawns in 055-3

### DIFF
--- a/world/map/npc/055-3/_mobs.txt
+++ b/world/map/npc/055-3/_mobs.txt
@@ -1,12 +1,14 @@
 // This file is generated automatically. All manually changes will be removed when running the Converter.
 // Cave mobs
 
-055-3.gat,45,44,20,14|monster|RedSlime|1008,13,10000,60000,Mob055-3::On1008
+055-3.gat,45,44,20,14|monster|RedSlime|1008,10,10000,60000,Mob055-3::On1008
 055-3.gat,0,0,1,1|monster|Bat|1017,20,10000,45000,Mob055-3::On1017
-055-3.gat,53,75,28,40|monster|YellowSlime|1007,13,10000,60000,Mob055-3::On1007
-055-3.gat,0,0,1,1|monster|BlackScorpion|1009,10,10000,35000,Mob055-3::On1009
-055-3.gat,0,0,1,1|monster|Spider|1012,10,10000,35000,Mob055-3::On1012
+055-3.gat,53,75,28,40|monster|YellowSlime|1007,10,10000,60000,Mob055-3::On1007
+055-3.gat,0,0,1,1|monster|BlackScorpion|1009,8,10000,35000,Mob055-3::On1009
+055-3.gat,0,0,1,1|monster|Spider|1012,8,10000,35000,Mob055-3::On1012
 055-3.gat,0,0,1,1|monster|Snake|1010,3,10000,20000,Mob055-3::On1010
+055-3.gat,46,44,14,18|monster|Spider|1012,3,50000,100000,Mob055-3::On1012
+055-3.gat,52,78,36,23|monster|BlackScorpion|1009,3,50000,100000,Mob055-3::On1009
 
 
 055-3.gat,0,0,0|script|Mob055-3|-1,


### PR DESCRIPTION
Copy & paste from https://github.com/themanaworld/tmwa-client-data/pull/186:

I don't enjoy making this change since this is my favorite spot for grinding slimes but it seems necessary to me since nearly everytime I'm there I meet botters.
Besides we have enough slimes grind places.
- reduced the maximum number of red and yellow slimes from 13 to 10
- changed spawn areas and maximum beings of Black Scorpions and Spiders so some automatically respawn where the slimes are

Makes botting harder in less effective without destroying this place for fair players.
