### PR TITLE
Mapflag correction for respawn on 046-1

### DIFF
--- a/world/map/npc/046-1/mapflags.txt
+++ b/world/map/npc/046-1/mapflags.txt
@@ -1,1 +1,1 @@
-046-1.gat|mapflag|resave|046-1,92,42
+046-1.gat|mapflag|resave|046-1,92,48

--- a/world/map/npc/046-3/mapflags.txt
+++ b/world/map/npc/046-3/mapflags.txt
@@ -1,1 +1,1 @@
-046-3.gat|mapflag|resave|046-1,92,42
+046-3.gat|mapflag|resave|046-1,92,48


### PR DESCRIPTION
92, 42 is not the same place anymore on the newer master (odd but fact is that the coordinates have changed for 046-1). It would be 92, 49 but the placement is okay anyway