### PR TITLE
remove fight club from hurnscald

### DIFF
--- a/world/map/npc/009-2/shops.txt
+++ b/world/map/npc/009-2/shops.txt
@@ -1,5 +1,5 @@
 // Bartender
-009-2.gat,65,49,0|shop|Barkeeper|112,Beer:*1,Cake:*1,Steak:*1
+009-2.gat,65,49,0|shop|Barkeeper|112,Beer:*1,Cake:*1,Steak:*1,ChickenLeg:*1
 
 // Receptionist
 // Offers the player to rest at the inn for 100gp
@@ -15,7 +15,7 @@
 009-2.gat,97,24,0|shop|Apprentice|120,SlingBullet:*1,Arrow:*2,IronArrow:*1,Bow:*1,ShortBow:*2
 
 // Potion Shop
-009-2.gat,123,22,0|shop|Potions#_M|400,CactusDrink:*1,CactusPotion:*1,IronPotion:*1,ConcentrationPotion:*1,SlowPoisonPotion:*1
+009-2.gat,123,22,0|shop|Potions#_M|400,SmallManaElixir:*5,CactusDrink:*1,CactusPotion:*1,IronPotion:*1,ConcentrationPotion:*1,SlowPoisonPotion:*1
 
 // General Store
-009-2.gat,32,99,0|shop|General Store#hurnscald|112,Milk:*1,BottleOfWater:*1,CottonShirt:*1,CottonShorts:*1,Boots:*1,SerfHat:*1,CottonHeadband:*1,CottonGloves:*1
+009-2.gat,32,99,0|shop|General Store#hurnscald|112,Milk:*1,BottleOfWater:*1,PickledBeets:*20,CottonShirt:*1,CottonShorts:*1,Boots:*1,SerfHat:*1,CottonHeadband:*1,CottonGloves:*1

--- a/world/map/npc/009-7/battlemaster.txt
+++ b/world/map/npc/009-7/battlemaster.txt
@@ -1,5 +1,6 @@
 009-7.gat,40,35,0|script|Battle Master#Duels|322
 {
+    if(getgmlevel() < 20) end;
     if($SANGUINE & $@SV_BMDBit != 0) goto L_Disabled;
     mes "[Battle Master]";
     mes "\"Hey, you seem tough enough! Would you like to prove your skills?\"";
@@ -44,6 +45,10 @@ L_PVP:
 L_NoMoney:
     mes "\"Wait a second, you don't have enough money.\"";
     close;
+
+OnInit:
+    if(!debug) disablenpc "Battle Master#Duels";
+    end;
 }
 
 
@@ -51,6 +56,7 @@ L_NoMoney:
 
 function|script|fightclub_GoBack
 {
+    if(!debug) end;
     set @Duel_PVP, DUELS & $@DuelPvpBit;
     if(@Duel_PVP != 0) goto L_GoBack;
     return;

--- a/world/map/npc/009-7/debug.txt
+++ b/world/map/npc/009-7/debug.txt
@@ -143,6 +143,7 @@ L_End:
 
 009-7.gat,41,45,0|script|Debug#Duels|181
 {
+    if(getgmlevel() < 20) end;
     mes "The debug menu can also be accessed by wearing a dev cap while talking to Rouge.";
     mes "For the documentation, @@https://wiki.themanaworld.org/index.php/User:Meko/FightClub/debug|click here@@##0";
     callfunc "fightclub_Debug";

--- a/world/map/npc/009-7/rouge.txt
+++ b/world/map/npc/009-7/rouge.txt
@@ -1,7 +1,8 @@
 009-7.gat,32,45,0|script|Rouge#Duels|181
 {
-if (getgmlevel() >= 40 && (getequipid(equip_head) == 647 || getequipid(equip_head) == 725)) goto L_CallDebug;
-goto L_Main;
+    if(getgmlevel() < 20) end;
+    if (getgmlevel() >= 40 && (getequipid(equip_head) == 647 || getequipid(equip_head) == 725)) goto L_CallDebug;
+    goto L_Main;
 
 L_CallDebug:
     mes "You are wearing a dev cap: calling debug menu...";
@@ -127,5 +128,9 @@ OnAnnounceBlueWins:
 
 OnAnnounceBlueForfeit:
     npctalk $@Duel_Queue_Blue$[0] + " wins by forfeit!";
+    end;
+
+OnInit:
+    if(!debug) disablenpc "Rouge#Duels";
     end;
 }

--- a/world/map/npc/009-7/trapdoor.txt
+++ b/world/map/npc/009-7/trapdoor.txt
@@ -1,5 +1,6 @@
 009-2.gat,38,105,0|script|#trapdoor#FightClub|327,0,0
 {
+    if(getgmlevel() < 20) end;
     set @index, rand(0,(getarraysize($@fightclub_randompasswords$) - 1));
     set @password$, $@fightclub_definitions$[@index];
     mes "[Bouncer]";
@@ -56,6 +57,7 @@ L_Close:
     close;
 
 OnInit:
+    if (!debug) disablenpc "#trapdoor#FightClub";
     setarray $@fightclub_randompasswords$, "Abibliophobia", "Anencephalous", "Batrachomyomachy", "Blunderbuss", "Boustrophedon", "Bumbershoot", "Canoodle", "Cockalorum", "Cockamamie", "Collywobbles", "Eructation", "Flibbertigibbet", "Formication", "Gaberlunzie", "Gastromancy", "Gobemouche", "Hemidemisemiquaver", "Hobbledehoy", "Hootenanny", "Lickspittle", "Lollygag", "Mumpsimus", "Nincompoop", "Oocephalus", "Pettifogger", "Sialoquent", "Slangwhanger", "Smellfungus", "Tatterdemalion", "Vomitory", "Widdershins", "Avoirdupois", "Embonpoint", "Bibble", "Erinaceous", "Impignorate", "Nudiustertian", "Tittynope", "Winklepicker", "Yarborough", "Floccinaucinihilipilification";
     setarray $@fightclub_definitions$, "The fear of running out of reading material","Lacking a brain","Making a mountain out of a molehill","A gun with a flared muzzle or disorganized activity","A back and forth pattern","An umbrella","To hug and kiss","A small, haughty man","Absurd, outlandish","Butterflies in the stomach","A burp, belch","Nonsense, balderdash","The sense of ants crawling on your skin","A wandering beggar","Telling fortune from the rumblings of the stomach","A highly gullible person","A musical timing of 1/64","An awkward or ill-mannered young boy","A country or folk music get-together","A servile person, a toady","To move slowly, fall behind","To move slowly, fall behind","A foolish person","An egghead","A person who tries to befuddle others with his speech","Spitting while speaking","A loud abusive speaker or obnoxious writer","A perpetual pessimist","A child in rags","An exit or outlet","In a contrary or counterclockwise direction", "Commodities sold by weight", "A plump, hourglass figure", "To drink often; to eat and/or drink noisily", "Resembling a hedgehog", "To pawn or mortgage something", "The day before yesterday", "A small quantity of something left over", "Style of shoe or boot with a sharp and long pointed toe", "Hand of cards containing no card above a nine", "Estimation that something is valueless";
     if(getarraysize($@fightclub_randompasswords$) != getarraysize($@fightclub_definitions$)) mapexit;


### PR DESCRIPTION
I kept the files of the fight club just in case that the killer/killable bug could one day be solved but for now it is disabled and can only be used on the test server if you are a dev. If the bug can not be fixed, I will remove all files of the fight club in the near future.

* Fight club no longer accessible
* Pickled Beets moved to General Store, price dropped
* Small Mana Elixir moved to the potion shop, price dropped
* Chicken Leg moved to Barkeeper