### PR TITLE
killmonsterall => killmonster

### DIFF
--- a/world/map/npc/052-1/janitor.txt
+++ b/world/map/npc/052-1/janitor.txt
@@ -7,7 +7,7 @@ end;
 OnCommandClean:
     // Kill all monsters (that includes the spawned Demonic Spirits and Azul Slimes)
     // Note that the loot the slimes may have picked will be deleted at the same time.
-    killmonsterall "052-1.gat";
+    killmonster "052-1", "All";
     // Delete the magic stones that are still laying around.
     // FIXME Syntax error happens if not setting a variable...
     set $@dummy_var, getareadropitem("052-1.gat", 1, 1, 98, 78, 873, 1) +


### PR DESCRIPTION
removes the buggy killmonsterall in favor of killmonster
according to the wiki, killmonsterall might prevent monsters from respawning.