### PR TITLE
npc 127 => 32767

### DIFF
--- a/world/map/npc/001-1/dock.txt
+++ b/world/map/npc/001-1/dock.txt
@@ -14,7 +14,7 @@
     close;
 }
 
-001-1,70,70,0|script|#TulimsharDock|127
+001-1,70,70,0|script|#TulimsharDock|32767
 {
     end;
 OnCommandArrive:

--- a/world/map/npc/002-2/inya.txt
+++ b/world/map/npc/002-2/inya.txt
@@ -1,7 +1,7 @@
 //Gemstones: Diamond (white) , Ruby (red), Emerald (green), Sapphire (blue), Topaz (yellow), Amethyst (purple)
 //The power of the gems is important to future balance of these rings. Are they related to stats, tiers of power, schools of magic?
 
-002-2,116,61,0|shop|#InyaShop|127,SimpleRing:*1
+002-2,116,61,0|shop|#InyaShop|32767,SimpleRing:*1
 
 002-2,116,61,0|script|Inya|106
 {

--- a/world/map/npc/002-2/latoy.txt
+++ b/world/map/npc/002-2/latoy.txt
@@ -1,7 +1,7 @@
 // A snobby store that won't sell to the player
 // takes part in quest given by 021-2/kylian.txt
 
-002-2,86,93,0|shop|#LatoyShop|127,SilkHeadband:*4,SilkGloves:*4,SilkPants:*4,SilkRobe:*4
+002-2,86,93,0|shop|#LatoyShop|32767,SilkHeadband:*4,SilkGloves:*4,SilkPants:*4,SilkRobe:*4
 
 002-2,86,93,0|script|Latoy|106
 {

--- a/world/map/npc/007-1/witch.txt
+++ b/world/map/npc/007-1/witch.txt
@@ -686,7 +686,7 @@ L_KillHero:
 
 }
 
-007-1,128,100,0|script|#IlliaDaemon|127
+007-1,128,100,0|script|#IlliaDaemon|32767
 {
 end;
 

--- a/world/map/npc/008-1/dock.txt
+++ b/world/map/npc/008-1/dock.txt
@@ -12,7 +12,7 @@
     close;
 }
 
-008-1,120,44,0|script|#Hurnscald NorthDock|127
+008-1,120,44,0|script|#Hurnscald NorthDock|32767
 {
     end;
 OnCommandArrive:
@@ -30,7 +30,7 @@ OnCommandWarp:
     close;
 }
 
-008-1,65,25,0|script|#Hurnscald SouthDock|127
+008-1,65,25,0|script|#Hurnscald SouthDock|32767
 {
     end;
 OnCommandArrive:

--- a/world/map/npc/009-2/peter.txt
+++ b/world/map/npc/009-2/peter.txt
@@ -1,5 +1,5 @@
 // Nicholas' Apprentice and Armorsmith
-009-2,183,57,0|shop|#PeterShop|127,Knife:*1,SharpKnife:*1,Dagger:*1
+009-2,183,57,0|shop|#PeterShop|32767,Knife:*1,SharpKnife:*1,Dagger:*1
 
 009-2,183,57,0|script|Peter|157
 {

--- a/world/map/npc/009-4/barriers.txt
+++ b/world/map/npc/009-4/barriers.txt
@@ -44,7 +44,7 @@ L_Error2:
 
 
 // Starting Barrier / Quest Entrance
-009-4,37,119,0|script|#OrumCaveStartMessage|127,0,0
+009-4,37,119,0|script|#OrumCaveStartMessage|32767,0,0
 {
     if (OrumQuest >= 3) end;
     if (OrumQuest == 2) goto L_Started;
@@ -58,7 +58,7 @@ L_Started:
     end;
 }
 
-009-4,37,120,0|script|#OrumCaveStartBarrier|127,0,0
+009-4,37,120,0|script|#OrumCaveStartBarrier|32767,0,0
 {
     if (OrumQuest >= 3) end;
     warp "009-4", 37, 118;
@@ -66,7 +66,7 @@ L_Started:
 }
 
 // First Barrier
-009-4,57,29,0|script|#OrumCaveFirstBarrier|127,0,0
+009-4,57,29,0|script|#OrumCaveFirstBarrier|32767,0,0
 {
     if (OrumQuest >= 5) end;
 
@@ -76,7 +76,7 @@ L_Started:
 }
 
 // Second Barrier
-009-4,61,55,0|script|#OrumCaveSecondMessage|127,0,0
+009-4,61,55,0|script|#OrumCaveSecondMessage|32767,0,0
 {
     if (OrumQuest >= 9) end;
     if (OrumQuest == 3) set OrumQuest, 4;
@@ -104,7 +104,7 @@ L_Advance_Quest:
     end;
 }
 
-009-4,61,54,0|script|#OrumCaveSecondBarrier|127,0,0
+009-4,61,54,0|script|#OrumCaveSecondBarrier|32767,0,0
 {
     if (OrumQuest >= 9) end;
     warp "009-4", 60, 56;
@@ -112,7 +112,7 @@ L_Advance_Quest:
 }
 
 // Third Barrier
-009-4,24,65,0|script|#OrumCaveThirdMessage|127,0,0
+009-4,24,65,0|script|#OrumCaveThirdMessage|32767,0,0
 {
     if (OrumQuest >= 10) end;
     if (OrumQuest == 3) set OrumQuest, 4;
@@ -154,7 +154,7 @@ L_Advance_Quest:
     end;
 }
 
-009-4,24,66,0|script|#OrumCaveThirdBarrier|127,0,0
+009-4,24,66,0|script|#OrumCaveThirdBarrier|32767,0,0
 {
     if (OrumQuest >= 10) end;
     warp "009-4", 23, 64;
@@ -162,7 +162,7 @@ L_Advance_Quest:
 }
 
 // Ending Barrier
-009-4,48,37,0|script|#OrumCaveEndMessage|127,0,0
+009-4,48,37,0|script|#OrumCaveEndMessage|32767,0,0
 {
     if (OrumQuest >= 11) end;
     if (OrumQuest == 3) set OrumQuest, 4;
@@ -274,7 +274,7 @@ L_Advance_Quest:
     close;
 }
 
-009-4,48,38,0|script|#OrumCaveEndBarrier|127,0,0
+009-4,48,38,0|script|#OrumCaveEndBarrier|32767,0,0
 {
     if (OrumQuest >= 11) end;
     warp "009-4", 47, 36;

--- a/world/map/npc/009-4/waric.txt
+++ b/world/map/npc/009-4/waric.txt
@@ -1,6 +1,6 @@
 //# see detailed description at orum.txt
 
-009-4,99,33,0|script|#WizardTrap|127,2,1
+009-4,99,33,0|script|#WizardTrap|32767,2,1
 {
     set @gender$, "They're";
     if (Sex == 0)

--- a/world/map/npc/009-7/battlemaster.txt
+++ b/world/map/npc/009-7/battlemaster.txt
@@ -62,29 +62,29 @@ L_GoBack:
     message strcharinfo(0), "Thank you for participating!";
     return;
 }
-009-6,36,48,0|script|#GoBack2Duels|127,0,1
+009-6,36,48,0|script|#GoBack2Duels|32767,0,1
 {
     callfunc "fightclub_GoBack";
     end;
 }
-009-5,53,74,0|script|#GoBack3Duels|127,3,1
+009-5,53,74,0|script|#GoBack3Duels|32767,3,1
 {
     callfunc "fightclub_GoBack";
     end;
 }
-009-3,158,83,0|script|#GoBack5Duels|127,7,0
+009-3,158,83,0|script|#GoBack5Duels|32767,7,0
 {
     callfunc "fightclub_GoBack";
     end;
 }
 
 
-001-2,130,22,0|script|#GoBack4Duels|127,1,1
+001-2,130,22,0|script|#GoBack4Duels|32767,1,1
 {
     callfunc "fightclub_GoBack";
     end;
 }
-001-3,73,28,0|script|#GoBack1Duels|127,0,1
+001-3,73,28,0|script|#GoBack1Duels|32767,0,1
 {
     callfunc "fightclub_GoBack";
     end;

--- a/world/map/npc/009-7/eventHandler.txt
+++ b/world/map/npc/009-7/eventHandler.txt
@@ -15,7 +15,7 @@ L_Enter:
     end;
 }
 
-009-7,22,38,0|script|#FightClubUtils|127
+009-7,22,38,0|script|#FightClubUtils|32767
 {
     end;
 
@@ -44,7 +44,7 @@ OnCommandIntrusion:
     end;
 }
 
-009-7,20,45,0|script|#FightClubTimeLimit|127,0,0
+009-7,20,45,0|script|#FightClubTimeLimit|32767,0,0
 {
     end;
 
@@ -76,7 +76,7 @@ OnInit:
     end;
 }
 
-009-7,20,44,0|script|#FightClubHandler|127,0,0
+009-7,20,44,0|script|#FightClubHandler|32767,0,0
 {
     end;
 

--- a/world/map/npc/012-1/shops.txt
+++ b/world/map/npc/012-1/shops.txt
@@ -1,6 +1,6 @@
 //
 
-012-1,36,99,0|shop|#FlowerShop|127,RedRose:*1,PinkRose:*1,YellowRose:*1,WhiteRose:*1,OrangeRose:*1,DarkRedRose:*1,RedTulip:*1,PinkTulip:*1,YellowTulip:*1,WhiteTulip:*1,OrangeTulip:*1
+012-1,36,99,0|shop|#FlowerShop|32767,RedRose:*1,PinkRose:*1,YellowRose:*1,WhiteRose:*1,OrangeRose:*1,DarkRedRose:*1,RedTulip:*1,PinkTulip:*1,YellowTulip:*1,WhiteTulip:*1,OrangeTulip:*1
 
 012-1,36,99,0|script|Blossom|163
 {

--- a/world/map/npc/013-1/flowerpentagram.txt
+++ b/world/map/npc/013-1/flowerpentagram.txt
@@ -1,4 +1,4 @@
-013-1,1,1,0|script|#FlowerPentagram|127
+013-1,1,1,0|script|#FlowerPentagram|32767
 {
 end;
 

--- a/world/map/npc/015-1/barrier.txt
+++ b/world/map/npc/015-1/barrier.txt
@@ -1,7 +1,7 @@
 // This barrier is for checking whether the player went outside after
 // progressing with the cat quest.
 
-015-1,59,32,0|script|#CatOutsideBarrier|127,1,1
+015-1,59,32,0|script|#CatOutsideBarrier|32767,1,1
 {
     set @catNeedsAlone, 0;
     end;

--- a/world/map/npc/017-9/secret.txt
+++ b/world/map/npc/017-9/secret.txt
@@ -1,4 +1,4 @@
-009-1,42,43,0|script|#SecretDoor|127,0,0
+009-1,42,43,0|script|#SecretDoor|32767,0,0
 {
     if (getgmlevel() < 40 && !debug) goto L_close;
     warp "017-9", 26, 25;
@@ -8,7 +8,7 @@ L_close:
     close;
 }
 
-020-1,60,76,0|script|#SecretDoor2|127,0,0
+020-1,60,76,0|script|#SecretDoor2|32767,0,0
 {
     if (getgmlevel() < 40 && !debug) goto L_close;
     warp "017-9", 22, 22;
@@ -18,7 +18,7 @@ L_close:
     close;
 }
 
-001-1,54,118,0|script|#SecretDoor3|127,0,0
+001-1,54,118,0|script|#SecretDoor3|32767,0,0
 {
     if (getgmlevel() < 40 && !debug) goto L_close;
     warp "017-9", 30, 22;
@@ -28,7 +28,7 @@ L_close:
     close;
 }
 
-027-2,118,111,0|script|#SecretDoor4|127,0,0
+027-2,118,111,0|script|#SecretDoor4|32767,0,0
 {
     if (getgmlevel() < 40 && !debug) goto L_close;
     warp "017-9", 30, 29;

--- a/world/map/npc/029-1/barrier.txt
+++ b/world/map/npc/029-1/barrier.txt
@@ -10,7 +10,7 @@ L_Block:
     end;
 }
 
-029-1,69,61,0|script|#CandorAnnouncer|127
+029-1,69,61,0|script|#CandorAnnouncer|32767
 {
     end;
 OnTalk:

--- a/world/map/npc/029-1/dock.txt
+++ b/world/map/npc/029-1/dock.txt
@@ -13,7 +13,7 @@
     close;
 }
 
-029-1,55,110,0|script|#CandorDock|127
+029-1,55,110,0|script|#CandorDock|32767
 {
     end;
 OnCommandArrive:

--- a/world/map/npc/031-1/dock.txt
+++ b/world/map/npc/031-1/dock.txt
@@ -13,7 +13,7 @@
     close;
 }
 
-031-1,100,100,0|script|#NivalisDock|127
+031-1,100,100,0|script|#NivalisDock|32767
 {
     end;
 

--- a/world/map/npc/051-1/janitor.txt
+++ b/world/map/npc/051-1/janitor.txt
@@ -1,5 +1,5 @@
 // Forest janitor
-051-1,1,1,0|script|#IlliaJanitor1|127
+051-1,1,1,0|script|#IlliaJanitor1|32767
 {
 end;
 
@@ -10,7 +10,7 @@ OnCommandClean:
 }
 
 // Desert janitor
-051-1,1,1,0|script|#IlliaJanitor3|127
+051-1,1,1,0|script|#IlliaJanitor3|32767
 {
 end;
 

--- a/world/map/npc/051-3/ambush.txt
+++ b/world/map/npc/051-3/ambush.txt
@@ -52,7 +52,7 @@ L_ShouldNotBeHere:
     end;
 }
 
-051-3,1,1,0|script|#BndtTl|127
+051-3,1,1,0|script|#BndtTl|32767
 {
     end;
 
@@ -141,7 +141,7 @@ L_CaptureHelper3:
 
 }
 
-051-3,29,94,0|script|Sneaky Bandit|127
+051-3,29,94,0|script|Sneaky Bandit|32767
 {
     end;
 
@@ -161,7 +161,7 @@ OnTimer3600:
 
 }
 
-051-3,33,95,0|script|Another Sneaky Bandit|127
+051-3,33,95,0|script|Another Sneaky Bandit|32767
 {
     end;
 

--- a/world/map/npc/051-3/janitor.txt
+++ b/world/map/npc/051-3/janitor.txt
@@ -1,5 +1,5 @@
 // Bandit cave janitor
-051-3,1,1,0|script|#IlliaJanitor2|127
+051-3,1,1,0|script|#IlliaJanitor2|32767
 {
 end;
 

--- a/world/map/npc/052-1/janitor.txt
+++ b/world/map/npc/052-1/janitor.txt
@@ -1,6 +1,6 @@
 // Illia Island janitor
 
-052-1,1,1,0|script|#IlliaJanitor4|127
+052-1,1,1,0|script|#IlliaJanitor4|32767
 {
 end;
 

--- a/world/map/npc/052-2/janitor.txt
+++ b/world/map/npc/052-2/janitor.txt
@@ -1,5 +1,5 @@
 // Lobby janitor
-052-2,1,1,0|script|#IlliaJanitor5|127
+052-2,1,1,0|script|#IlliaJanitor5|32767
 {
 end;
 
@@ -12,7 +12,7 @@ OnCommandClean:
 }
 
 // Storage janitor
-052-2,1,1,0|script|#IlliaJanitor6|127
+052-2,1,1,0|script|#IlliaJanitor6|32767
 {
 end;
 
@@ -24,7 +24,7 @@ OnCommandClean:
 }
 
 // Final boss janitor
-052-2,1,1,0|script|#IlliaJanitor7|127
+052-2,1,1,0|script|#IlliaJanitor7|32767
 {
 end;
 

--- a/world/map/npc/052-2/partyroom.txt
+++ b/world/map/npc/052-2/partyroom.txt
@@ -83,7 +83,7 @@ OnTimer15000:
 
 }
 
-052-2,88,15,0|script|#LuviaDaemon|127
+052-2,88,15,0|script|#LuviaDaemon|32767
 {
 end;
 

--- a/world/map/npc/052-2/storage.txt
+++ b/world/map/npc/052-2/storage.txt
@@ -27,7 +27,7 @@ L_StartItemInvoker:
 
 }
 
-052-2,1,1,0|script|#ItemsInvoker|127
+052-2,1,1,0|script|#ItemsInvoker|32767
 {
 end;
 


### PR DESCRIPTION
Since npc 127 is invisible and non target-able it makes no sense to send it to the client. Npc 32767 is better in this case because [it does not send the npc to the client](https://github.com/themanaworld/tmwa/blob/master/src/map/clif.cpp#L909). At this point I don't see any real reason to keep npc 127 in the client-data but it is still used by tmwa ([magic](https://github.com/themanaworld/tmwa/blob/master/src/map/magic-stmt.cpp#L61) & [npc](https://github.com/themanaworld/tmwa/blob/master/src/map/npc.hpp#L43)) so I think it should be kept.

- - -
Update: It looks like 127 has its own use cases. It is necessary when using specialeffect builtin. Updated this PR to revert npcs with specialeffect