### PR TITLE
Make warp towels honor noteleport and nowarp

### DIFF
--- a/world/map/npc/items/warpTowels.txt
+++ b/world/map/npc/items/warpTowels.txt
@@ -6,7 +6,7 @@ function|script|WarpTowel
         goto L_DontPanic;
     if (isin("botcheck",25,27,51,47))
         goto L_Prison;
-    if (getmapflag(getmap(), MF_NOSAVE) || isin("009-7",$@fightclub_x1,$@fightclub_y1,$@fightclub_x2,$@fightclub_y2))
+    if (getmapflag(getmap(), MF_NOSAVE) || getmapflag(getmap(), MF_NOTELEPORT) || getmapflag(getmap(), MF_NOWARP) || isin("009-7",$@fightclub_x1,$@fightclub_y1,$@fightclub_x2,$@fightclub_y2))
         goto L_Forbid;
 
     callfunc "MultiWarpTowel";


### PR DESCRIPTION
```noteleport``` makes the player unable to use warp towel
```nowarp``` makes the player AND GMs (with gm level under ```battle_config.any_warp_GM_min_level```) unable to warp or use warp towel

- - - 
noteleport is also checked by the ```warp``` builtin when using map name "Random" (which is not used anywhere). Since it's useless I removed it in https://github.com/themanaworld/tmwa/pull/57