### PR TITLE
deprecate debug npcs

### DIFF
--- a/world/map/npc/functions/debug.txt
+++ b/world/map/npc/functions/debug.txt
@@ -2,7 +2,12 @@
 
 function|script|Debug
 {
-    goto L_Begin;
+    if(!@debug_npc) goto L_Begin;
+    mes "The debug NPCs have been deprecated. Please use this magic spell instead:";
+    mes "";
+    mes "%%E        ##a"+ getspellinvocation("debug0") +"##0";
+    set @debug_npc, 0;
+    close;
 
 L_Begin:
     set @debug_mask, 65535;
@@ -918,6 +923,7 @@ L_Close:
 
 029-2,30,26,0|script|Debug#0|154
 {
+    set @debug_npc, 1;
     callfunc "Debug";
     end;
 OnInit:
@@ -928,6 +934,7 @@ OnInit:
 
 001-1,53,47,0|script|Debug#1|154
 {
+    set @debug_npc, 1;
     callfunc "Debug";
     end;
 OnInit:
@@ -938,6 +945,7 @@ OnInit:
 
 009-1,52,33,0|script|Debug#2|154
 {
+    set @debug_npc, 1;
     callfunc "Debug";
     end;
 OnInit:
@@ -948,6 +956,7 @@ OnInit:
 
 020-1,75,85,0|script|Debug#3|154
 {
+    set @debug_npc, 1;
     callfunc "Debug";
     end;
 OnInit:
@@ -956,18 +965,9 @@ OnInit:
     end;
 }
 
-017-9,21,24,0|script|Debug#4|154
-{
-    callfunc "Debug";
-    end;
-OnInit:
-    if (!debug)
-        disablenpc "Debug#4";
-    end;
-}
-
 027-2,125,103,0|script|Debug#5|154
 {
+    set @debug_npc, 1;
     callfunc "Debug";
     end;
 OnInit:


### PR DESCRIPTION
once we completely remove the npcs, we could display a message with onlogin showing the base atcommands, how to test and how to access debug

- - - 
side note: at first I wanted it to use the `@caster_name$` variable (auto-set by magic) but it does not reset itself so it's not reliable.. I'll probably edit magic-stmt in the future to fix that