### PR TITLE
remove close builtin from functions

### DIFF
--- a/world/map/conf/magic-level2.sex
+++ b/world/map/conf/magic-level2.sex
@@ -899,6 +899,7 @@
                 (SCRIPT "{
                     set @flag, 1;
                     callfunc \"QuestTreeTrigger\";
+                    close;
                 }"))
             (IF (is_in
                     (location caster)

--- a/world/map/conf/magic-quests.sex
+++ b/world/map/conf/magic-quests.sex
@@ -19,6 +19,7 @@
         (SCRIPT "{
             set @flag, 2;
             callfunc \"QuestTreeTrigger\";
+            close;
         }")))
 
 (SPELL (NONMAGIC) hug0 "hug" (STRING target)

--- a/world/map/npc/002-1/mine_debug.txt
+++ b/world/map/npc/002-1/mine_debug.txt
@@ -33,7 +33,7 @@ L_Show:
 
 L_Close:
     set @state, 0;
-    close;
+    return;
 
 S_Update_Var:
     set QUEST_SouthTulimshar, (QUEST_SouthTulimshar & ~(BYTE_2_MASK) | (@state << BYTE_2_SHIFT));
@@ -42,7 +42,7 @@ S_Update_Var:
 002-1,61,69,0|script|Mine Debug#1|122
 {
     callfunc "DesertMineDebug";
-    end;
+    close;
 
 OnInit:
     if (!debug)
@@ -52,7 +52,7 @@ OnInit:
 002-3,45,49,6|script|Mine Debug#2|109
 {
     callfunc "DesertMineDebug";
-    end;
+    close;
 
 OnInit:
     if (!debug)
@@ -62,7 +62,7 @@ OnInit:
 002-4,88,99,6|script|Mine Debug#3|109
 {
     callfunc "DesertMineDebug";
-    end;
+    close;
 
 OnInit:
     if (!debug)
@@ -72,7 +72,7 @@ OnInit:
 002-5,43,96,6|script|Mine Debug#4|340
 {
     callfunc "DesertMineDebug";
-    end;
+    close;
 
 OnInit:
     if (!debug)

--- a/world/map/npc/002-2/kylian.txt
+++ b/world/map/npc/002-2/kylian.txt
@@ -404,12 +404,12 @@ L_MoreWorkTimer:
     goto L_Menu;
 
 L_Close:
-    close;
+    return;
 }
 002-2,40,101,0|script|KylianDebug#1|193
 {
     callfunc "KylianDebug";
-    end;
+    close;
 OnInit:
     if (!debug)
         disablenpc "KylianDebug#1";
@@ -418,7 +418,7 @@ OnInit:
 002-2,118,89,0|script|KylianDebug#2|193
 {
     callfunc "KylianDebug";
-    end;
+    close;
 OnInit:
     if (!debug)
         disablenpc "KylianDebug#2";

--- a/world/map/npc/006-1/spirit.txt
+++ b/world/map/npc/006-1/spirit.txt
@@ -4,7 +4,7 @@ function|script|EarthImpTouch
 
     mes "[Well]";
     mes "You hear noises from within the well.";
-    close;
+    return;
 
 L_message:
     set @Q_MASK, NIBBLE_0_MASK;
@@ -279,7 +279,7 @@ L_Close:
     set @Q_STATUS_STUDENT2, 0;
     set @Q_STATUS_STUDENT3, 0;
     set @s$, "";
-    close;
+    return;
 
 S_update_var:
     set QUEST_MAGIC2, (QUEST_MAGIC2 & ~(@Q_MASK) | (@Q_status << @Q_SHIFT));
@@ -289,11 +289,11 @@ S_update_var:
 006-1,63,79,0|script|#EarthImp0#_M|400
 {
     callfunc "EarthImpTouch";
-    end;
+    close;
 }
 
 006-1,64,79,0|script|#EarthImp1#_M|400
 {
     callfunc "EarthImpTouch";
-    end;
+    close;
 }

--- a/world/map/npc/006-1/tree.txt
+++ b/world/map/npc/006-1/tree.txt
@@ -39,7 +39,7 @@ L_Close:
     set @Q_status_lower, 0;
     set @Q_wr_status, 0;
     set @value, 0;
-    close;
+    return;
 
 S_update_var:
     set @Q_wr_status, (@Q_status << 2) | @Q_status_lower;
@@ -151,18 +151,18 @@ L_Close:
     set @Q_MASK, 0;
     set @Q_SHIFT, 0;
     set @Q_status, 0;
-    close;
+    return;
 
 }
 
 006-1,82,59,0|script|#DruidTree0#_M|400
 {
     callfunc "QuestTreeTouch";
-    end;
+    close;
 }
 
 006-1,83,59,0|script|#DruidTree1#_M|400
 {
     callfunc "QuestTreeTouch";
-    end;
+    close;
 }

--- a/world/map/npc/009-4/barriers.txt
+++ b/world/map/npc/009-4/barriers.txt
@@ -15,7 +15,8 @@ L_GetBarrierColor:
 
 L_Error:
     mes "Barrier number is out of range.";
-    close;
+    close2;
+    return;
 
 L_Error2:
     callfunc "SetUpOrumQuest";
@@ -35,11 +36,13 @@ function|script|SetBarrierColor
 
 L_Error:
     mes "Barrier number is out of range.";
-    close;
+    close2;
+    return;
 
 L_Error2:
     mes "Barrier color is out of range.";
-    close;
+    close2;
+    return;
 }
 
 

--- a/world/map/npc/009-4/torches.txt
+++ b/world/map/npc/009-4/torches.txt
@@ -10,7 +10,8 @@ function|script|GetTorchColor
 
 L_Error:
     mes "Torch number is out of range.";
-    close;
+    close2;
+    return;
 }
 
 function|script|SetTorchColor
@@ -24,11 +25,13 @@ function|script|SetTorchColor
 
 L_Error:
     mes "Torch number is out of range.";
-    close;
+    close2;
+    return;
 
 L_Error2:
     mes "Torch color is out of range.";
-    close;
+    close2;
+    return;
 }
 
 function|script|GetTorchIntensity
@@ -42,7 +45,8 @@ function|script|GetTorchIntensity
 
 L_Error:
     mes "Torch number is out of range.";
-    close;
+    close2;
+    return;
 }
 
 function|script|SetTorchIntensity
@@ -56,11 +60,13 @@ function|script|SetTorchIntensity
 
 L_Error:
     mes "Torch number is out of range.";
-    close;
+    close2;
+    return;
 
 L_Error2:
     mes "Torch intensity is out of range.";
-    close;
+    close2;
+    return;
 }
 
 function|script|DoneWithTorches
@@ -75,12 +81,14 @@ function|script|DoneWithTorches
 
     if (OrumQuest < 8)
         mes "Without that powder the note mentions there isn't much you can do with this torch.";
-    close;
+    close2;
+    goto L_Return;
 
 L_Different:
     mes "The flame on this torch looks different than the rest. You better tell Orum about it before doing anything.";
     set OrumQuest, 6;
-    close;
+    close2;
+    goto L_Return;
 
 L_Return:
     return;
@@ -92,7 +100,8 @@ function|script|InRangeTorch1
     if (isin("009-4",67,20,69,25))
         goto L_Return;
     mes "You're too far away to do anything with that torch.";
-    close;
+    close2;
+    goto L_Return;
 
 L_Return:
     return;
@@ -102,7 +111,8 @@ function|script|InRangeTorch2
     if (isin("009-4",65,41,69,46))
         goto L_Return;
     mes "You're too far away to do anything with that torch.";
-    close;
+    close2;
+    goto L_Return;
 
 L_Return:
     return;
@@ -112,7 +122,8 @@ function|script|InRangeTorch3
     if (isin("009-4",33,84,37,88))
         goto L_Return;
     mes "You're too far away to do anything with that torch.";
-    close;
+    close2;
+    goto L_Return;
 
 L_Return:
     return;
@@ -144,7 +155,8 @@ L_Color_Loop:
 
 L_Leave:
     mes "The flame flickers as if it's laughing at you.";
-    close;
+    close2;
+    return;
 
 L_Use_Red:
     if (countitem("RedPowder") < 1)
@@ -228,7 +240,8 @@ L_Use_Blue:
 
 L_No_Powder:
     mes "You notice you're all out of that color of powder. Perhaps Orum can make you some more.";
-    close;
+    close2;
+    return;
 
 L_Color_Dec:
     set @TorchColor, @TorchColor - 1;
@@ -277,7 +290,8 @@ L_Failed:
     set @TorchIntensity, 0;
     callfunc "SetTorchIntensity";
     heal -Hp, 0;
-    close;
+    close2;
+    return;
 }
 
 // First Torch

--- a/world/map/npc/009-7/core.txt
+++ b/world/map/npc/009-7/core.txt
@@ -85,11 +85,11 @@ L_Loop:
 
 L_Exists:
     mes "This battle is already in the queue.";
-    close;
+    return;
 
 L_Full:
     mes "There is already " + $@Duel_QueueLimit + " battles in the queue, which is the maximum. Please try again later.";
-    close;
+    return;
 
 L_Proceed2:
     if(getarraysize($@Duel_Queue_ID) >= ($@Duel_QueueLimit + 1)) goto L_Full;

--- a/world/map/npc/012-1/injured-mouboo.txt
+++ b/world/map/npc/012-1/injured-mouboo.txt
@@ -29,11 +29,13 @@ function|script|QuestMoubooHeal
     next;
     set @value, 15;
     callfunc "QuestSagathaHappy";
-    close;
+    close2;
+    return;
 
 L_nothing:
     mes "Your spell has no effect.";
-    close;
+    close2;
+    return;
 
 S_update_var:
     set @Q_wr_status, @Q_status | @Q_status_upper;
@@ -168,7 +170,7 @@ L_consume:
 
 L_do_heal:
     callfunc "QuestMoubooHeal";
-    goto L_kill;
+    end;
 
 L_kill:
     mes "[Injured Mouboo]";

--- a/world/map/npc/027-1/graves.txt
+++ b/world/map/npc/027-1/graves.txt
@@ -1,19 +1,9 @@
 // Easter egg graves
 
-function|script|GraveTooFar
-{
-    if (isin("027-1",89,54,122,76))
-        goto L_Return;
-    mes "You are too far away to read the grave.";
-    close;
-
-L_Return:
-    return;
-}
-
 027-1,89,62,0|script|Grave#1|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ FotherJ ~";
     mes "The mad sprite making genius who made all the creepy undead monster graphics.";
     close;
@@ -21,7 +11,8 @@ L_Return:
 
 027-1,118,54,0|script|Grave#2|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Yosuhara ~";
     mes "Contributed some of the tombstones.";
     close;
@@ -29,7 +20,8 @@ L_Return:
 
 027-1,111,62,0|script|Grave#3|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Feline Monstrosity ~";
     mes "Made the background music you are hearing.";
     close;
@@ -37,7 +29,8 @@ L_Return:
 
 027-1,112,76,0|script|Grave#4|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Superkoop ~";
     mes "Mapped the swamp to the south.";
     close;
@@ -45,7 +38,8 @@ L_Return:
 
 027-1,120,76,0|script|Grave#5|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Aroleon ~";
     mes "Mapped the swamp to the southeast.";
     close;
@@ -53,7 +47,8 @@ L_Return:
 
 027-1,100,68,0|script|Grave#6|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ John P ~";
     mes "Wrote the graveyard backstory and the dialog for the caretaker quest.";
     close;
@@ -61,7 +56,8 @@ L_Return:
 
 027-1,94,70,0|script|Grave#7|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Spit23 ~";
     mes "Made those freakin awesome cemetery gates.";
     close;
@@ -69,7 +65,8 @@ L_Return:
 
 027-1,106,60,0|script|Grave#8|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Black Don ~";
     mes "Contributed those cool gargoyle statues.";
     close;
@@ -77,7 +74,8 @@ L_Return:
 
 027-1,92,54,0|script|Grave#9|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Jaxad0127 ~";
     mes "Did all the scripting work for the graveyard. Made Caretaker's house.";
     close;
@@ -85,7 +83,8 @@ L_Return:
 
 027-1,122,64,0|script|Grave#10|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Ces Vargavind ~";
     mes "Scripted caretaker's daughter.";
     close;
@@ -93,7 +92,8 @@ L_Return:
 
 027-1,102,62,0|script|Grave#11|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Crush ~";
     mes "Organizer of the whole graveyard project, graveyard fence graphics, mapping of the graveyard itself.";
     close;
@@ -101,7 +101,8 @@ L_Return:
 
 027-1,104,76,0|script|Grave#12|400
 {
-    callfunc "GraveTooFar";
+    set @npc_distance, 1;
+    callfunc "PCtoNPCRange";
     mes "~ Freeyorp ~";
     mes "Planned out monster stats and placements.";
     close;

--- a/world/map/npc/030-2/eljas.txt
+++ b/world/map/npc/030-2/eljas.txt
@@ -5,6 +5,7 @@
 {
     callfunc "XmasStates";
     callfunc "ThrowOutTheBum";
+    if(@getout) end;
     goto L_Start;
 
 L_Start:
@@ -201,6 +202,7 @@ L_End:
 OnTouch:
     callfunc "XmasStates";
     callfunc "ThrowOutTheBum";
+    if(@getout) end;
     if((@xmas_list_gather) || !($@xmas_time))
         goto L_End;
     goto L_Start;

--- a/world/map/npc/030-2/guards.txt
+++ b/world/map/npc/030-2/guards.txt
@@ -4,6 +4,7 @@
 {
     callfunc "XmasStates";
     callfunc "ThrowOutTheBum";
+    if(@getout) end;
     mes "[Valjas]";
     mes "\"...\"";
     close;
@@ -13,6 +14,7 @@
 {
     callfunc "XmasStates";
     callfunc "ThrowOutTheBum";
+    if(@getout) end;
     mes "[Halas]";
     mes "\"...\"";
     close;
@@ -22,6 +24,7 @@
 {
     callfunc "XmasStates";
     callfunc "ThrowOutTheBum";
+    if(@getout) end;
     mes "[Kilis]";
     mes "\"...\"";
     close;

--- a/world/map/npc/030-2/shipping_helper.txt
+++ b/world/map/npc/030-2/shipping_helper.txt
@@ -115,5 +115,5 @@ L_Close:
     mes "\"Ok, back to work you two, we have to make up lost time for your antics.\"";
     set @wrap$, "";
     set @present_name$, "";
-    close;
+    return;
 }

--- a/world/map/npc/052-1/channelling.txt
+++ b/world/map/npc/052-1/channelling.txt
@@ -126,8 +126,7 @@ function|script|StartChannelling
 
     message strcharinfo(0), "Ok, let's stay focused now!";
     donpcevent "#Power Circle::OnCommandSt";
-    close;
-
+    return;
 }
 
 052-1,53,38,0|script|#Power Circle|368

--- a/world/map/npc/annuals/halloween/debug.txt
+++ b/world/map/npc/annuals/halloween/debug.txt
@@ -1,4 +1,4 @@
-// Halloween Debug 
+// Halloween Debug
 // Author: Wushin
 
 function|script|HalloweenDebug
@@ -137,5 +137,6 @@ L_Close:
     set @loop, 0;
     set @menu, 0;
     set @halloween_npc_id, 0;
-    close;
+    close2;
+    return;
 }

--- a/world/map/npc/annuals/xmas/barriers.txt
+++ b/world/map/npc/annuals/xmas/barriers.txt
@@ -4,6 +4,7 @@
 
 function|script|ThrowOutTheBum
 {
+    set @getout, 0;
     if((@xmas_thrown_out) && ($@xmas_time))
         goto L_SideOut;
     goto L_Return;
@@ -18,13 +19,16 @@ L_Hint:
     mes "[Orum's Homunculus]";
     mes "\"What are you doing? Come, see me in the caves below!\"";
     mes "\"I said go north till you reach the snowman. Then head into the cave to the east.\"";
+    close2;
     warp "020-1.gat",33,94;
-    close;
+    set @getout, 1;
+    goto L_Return;
 
 L_Warp:
     message strcharinfo(0), "I said get out, We've no time for your kind here.";
     warp "020-1.gat",33,94;
-    end;
+    set @getout, 1;
+    goto L_Return;
 
 L_Return:
     return;

--- a/world/map/npc/annuals/xmas/debug.txt
+++ b/world/map/npc/annuals/xmas/debug.txt
@@ -168,7 +168,8 @@ L_Close:
     set @xmas_time_key_rsday, 0;
     set @xmas_time_key_reday, 0;
     set @xmas_time_key_year, 0;
-    close;
+    close2;
+    return;
 }
 
 020-1.gat,86,76,0|script|XmasDebug#1|105

--- a/world/map/npc/functions/banker.txt
+++ b/world/map/npc/functions/banker.txt
@@ -213,7 +213,7 @@ L_Balance:
     mes "[" + @npcname$ + "]";
     mes "\"Your current bank balance is:";
     mes #BankAccount + " GP\"";
-    if (#BankOptions & OPT_BANK_CLOSE) close;
+    if (#BankOptions & OPT_BANK_CLOSE) goto L_Return;
     goto L_Start;
 
 L_Nev:

--- a/world/map/npc/functions/debug.txt
+++ b/world/map/npc/functions/debug.txt
@@ -912,7 +912,8 @@ L_ResetAll:
     goto L_Begin;
 
 L_Close:
-    close;
+    close2;
+    return;
 
 }
 

--- a/world/map/npc/functions/ferry.txt
+++ b/world/map/npc/functions/ferry.txt
@@ -123,7 +123,8 @@ L_WorldFerry:
     goto L_Close;
 
 L_Close:
-    close;
+    close2;
+    return;
 }
 
 function|script|BoardFerry

--- a/world/map/npc/functions/inn.txt
+++ b/world/map/npc/functions/inn.txt
@@ -25,7 +25,8 @@ L_Close:
     mes "[" + @npcname$ + "]";
     mes "\"See you.\"";
     set @npcname$, "";
-    close;
+    close2;
+    return;
 
 L_NoMoney:
     mes "[" + @npcname$ + "]";

--- a/world/map/npc/functions/magic.txt
+++ b/world/map/npc/functions/magic.txt
@@ -13,7 +13,7 @@
 function|script|MagicGainBasic
 {
     set MAGIC_FLAGS, MAGIC_FLAGS | MFLAG_DRANK_POTION;
-    close;
+    return;
 }
 
 // ------------------------------------------------------------

--- a/world/map/npc/functions/slot_machine.txt
+++ b/world/map/npc/functions/slot_machine.txt
@@ -27,16 +27,17 @@ L_Play:
     mes "Congratulations! You won!";
     mes "You get 10 casino coins";
     getitem "CasinoCoins", 10;
-    close;
+    goto L_Close;
 
 L_Lost:
     mes "You lost!";
-    close;
+    goto L_Close;
 
 L_NoCoin:
     mes "Insert coin";
-    close;
+    goto L_Close;
 
 L_Close:
-    close;
+    close2;
+    return;
 }

--- a/world/map/npc/functions/undead_debug.txt
+++ b/world/map/npc/functions/undead_debug.txt
@@ -78,7 +78,8 @@ L_TeroganItems:
     goto L_Main;
 
 L_Close:
-    close;
+    close2;
+    return;
 }
 
 // Debug for Krukan

--- a/world/map/npc/functions/water_bottle.txt
+++ b/world/map/npc/functions/water_bottle.txt
@@ -8,7 +8,7 @@ function|script|WaterBottle
     input @count;
 
     if (@count == 0)
-        close;
+        goto L_Close;
     set @cost, @count * @COST_PER_BOTTLE;
     set @empty, countitem("EmptyBottle");
 
@@ -25,17 +25,21 @@ function|script|WaterBottle
     set Zeny, Zeny - @cost;
     delitem "EmptyBottle", @count;
     getitem "BottleOfWater", @count;
-    close;
+    goto L_Close;
 
 L_NotEnoughBottles:
     mes "You don't have that many empty bottles!";
-    close;
+    goto L_Close;
 
 L_NotEnoughMoney:
     mes "You don't have enough gp! You need " + @cost + "gp.";
-    close;
+    goto L_Close;
 
 L_NotEnoughSlots:
     mes "You don't have room for these bottles!";
-    close;
+    goto L_Close;
+
+L_Close:
+    close2;
+    return;
 }


### PR DESCRIPTION
A function should ALWAYS return under any circumstances. The builtins `close` and `end` should not be allowed inside a function or sub.

todo:
remove `end;` from functions

note to self: list of functions that may or may not have `end;` => https://gist.github.com/mekolat/e90e792b2b3ed347fc93