### PR TITLE
death to the motd!

### DIFF
--- a/world/map/.gitignore
+++ b/world/map/.gitignore
@@ -3,3 +3,5 @@
 /news.phpbb.txt
 
 /db/const-debugflag.txt
+
+/npc/functions/motd.txt

--- a/world/map/conf/.gitignore
+++ b/world/map/conf/.gitignore
@@ -1,5 +1,4 @@
 /*_local.conf
 /magic-secrets.conf
 /magic-secrets.sex
-/motd.txt
 /secrets-build

--- a/world/map/conf/map_athena.conf
+++ b/world/map/conf/map_athena.conf
@@ -3,9 +3,6 @@
 // Database autosave time, in seconds.
 autosave_time: 60
 
-// Message of the day file, when a character logs on, this message is displayed.
-motd_txt: conf/motd.txt
-
 mapreg_txt: save/mapreg.txt
 
 import: npc/scripts.conf

--- a/world/map/conf/motd.txt.example
+++ b/world/map/conf/motd.txt.example
@@ -1,2 +1,0 @@
-Welcome to The Mana World! (running on tmwAthena)
-You can report abuse by typing in chat: @wgm Player XYZ is abusing me

--- a/world/map/npc/functions/announcements.txt
+++ b/world/map/npc/functions/announcements.txt
@@ -1,0 +1,14 @@
+function|script|DisplayMOTD
+{
+    if($@MOTD_Disabled || $@MOTD$[0] == "") goto L_Return;
+    goto L_MOTD;
+
+L_MOTD:
+    message strcharinfo(0), "##7Server : " + $@MOTD$[@motd_index];
+    set @motd_index, @motd_index + 1;
+    if($@MOTD$[@motd_index] == "") goto L_Return;
+    goto L_MOTD;
+
+L_Return:
+    return;
+}

--- a/world/map/npc/functions/clear_vars.txt
+++ b/world/map/npc/functions/clear_vars.txt
@@ -437,5 +437,5 @@ L_EventClear:
 
 // Variable was used in Voltain's script, was renamed and turned into a temporary variable
     set $state, 0;
-    end;
+    return;
 }

--- a/world/map/npc/functions/global_event_handler.txt
+++ b/world/map/npc/functions/global_event_handler.txt
@@ -11,6 +11,7 @@ OnPCLoginEvent:
     set @login_event, 1;
     callfunc "getHeadStyles"; // converts class, color and hair
     callfunc "ClearVariables"; // removes / converts old variables
+    callfunc "DisplayMOTD"; // send the motd to the client, if enabled
     // add more here
     set @login_event, 2;
     end;
@@ -30,5 +31,6 @@ OnPCDieEvent:
 
 OnInit: //fixme: change to OnInterIfInit
     callfunc "ClearGlobalVars";
+    callfunc "MOTD"; // set the MOTD array
     end;
 }

--- a/world/map/npc/functions/motd.txt.example
+++ b/world/map/npc/functions/motd.txt.example
@@ -1,0 +1,11 @@
+function|script|MOTD
+{
+    setarray $@MOTD$,
+
+        "Welcome to The Mana World! (running on tmwAthena)",
+        "[@@http://ow.ly/MCesp|Website & Wiki@@] [@@http://ow.ly/MCeBR|Vote For GMs@@] [@@http://ow.ly/MCehc|Bug Reports@@] [@@http://ow.ly/MCe5W|Live Support@@]",
+        "Like us on [@@http://ow.ly/MCdZW|Facebook@@] [@@http://ow.ly/MCdTt|G+@@] [@@http://ow.ly/MCdJR|Youtube@@] [@@http://ow.ly/MCePp|Twitter@@]",
+        "You can report abuse by typing in chat: @wgm Player XYZ is abusing me";
+
+    return;
+}

--- a/world/map/npc/scripts.conf
+++ b/world/map/npc/scripts.conf
@@ -28,6 +28,8 @@ npc: npc/functions/stat_reset.txt
 npc: npc/functions/quiz.txt
 npc: npc/functions/dynamic_menu.txt
 npc: npc/functions/DyeConfig.txt
+npc: npc/functions/announcements.txt
+npc: npc/functions/motd.txt
 
 // Item Functions
 npc: npc/items/magic_gm_top_hat.txt


### PR DESCRIPTION
closes #373
requires https://github.com/themanaworld/tmwa/pull/87

There is no option to disable it yet because I will add it to [Numa](https://github.com/themanaworld/tmwa-server-data/pull/360) once this PR is merged (and you will need to remove test label from #360 to test this one)

To test:
1) build themanaworld/tmwa#87
2) remove your local `motd.txt` - optional
3) `ln -s ~/tmwAthena/tmwa-server-data/world/map/npc/functions/motd.txt.example ~/tmwAthena/world/map/npc/functions/motd.txt` (or just `cp` it)