### PR TITLE
make cindy quest re-doable

### DIFF
--- a/world/map/npc/031-1/angelaOutside.txt
+++ b/world/map/npc/031-1/angelaOutside.txt
@@ -1,28 +1,29 @@
 // author: Jenalya
-// state0: Angela is to upset to tell you anything, needs a concentration potion
-// state1: got the mission to save Cindy
-// state2 and state3: Cindy is saved Angela invites you to visit them for giving a reward
-// state greater than 3: Angela invites and asks you to bring present boxes
 
 031-1,81,24,0|script|Debug#Angela|195
 {
     mes "Current state: " + QL_CINDY;
     mes "---";
     mes "Available states:";
-    mes "0 - can not do the quest.";
-    mes "5 - does not have the quest.";
-    mes "6 - got the quest.";
-    mes "1 - can go rescue cindy.";
-    mes "2 - rescued cindy.";
-    mes "3 - got reward from cindy.";
-    mes "4 - got reward from angela.";
+    mes "0  - can not do the quest.";
+    mes "5  - does not have the quest.";
+    mes "6  - got the quest.";
+    mes "1  - can go rescue cindy.";
+    mes "7  - started once.";
+    mes "8  - started twice.";
+    mes "9  - started thrice.";
+    mes "         (...)";
+    mes "16 - started 10 times.";
+    mes "2  - rescued cindy.";
+    mes "3  - got reward from cindy.";
+    mes "4  - got reward from angela.";
     menu
         "set state", L_Set,
         "close", L_Close;
 
 L_Set:
     input @state;
-    if(@state < 0 || @state > 6) set @state, 0;
+    if(@state < 0 || @state > 16) set @state, 0;
     set QL_CINDY, @state;
     goto L_Close;
 
@@ -40,7 +41,7 @@ OnInit:
 
     if (QL_CINDY == 3) goto L_Please_Visit_Again;
     if (QL_CINDY > 1 && QL_CINDY < 5) goto L_Please_Visit;
-    if (QL_CINDY == 1) goto L_Please_Help;
+    if (QL_CINDY == 1 || QL_CINDY >= 7) goto L_Please_Help;
 
     mes "[Angela]";
     mes "\"Please, I need help! My little daughter!\"";

--- a/world/map/npc/031-4/cindyCave.txt
+++ b/world/map/npc/031-4/cindyCave.txt
@@ -8,15 +8,16 @@
 {
     if ($@FIGHT_YETI_STATUS != 0) goto L_Yeti;
 
-    set @KEYS_AMOUNT, 10;
+    set @KEYS_AMOUNT, 10; // the number of keys required to do the quest
+    set @KEYS_REDO,    0; // the number of keys it takes to re-do the quest once completed (added to base @KEYS_AMOUNT)
     set @minlevel, 70;
 
     if (Sex == 0) set @title$, "Misses";
     if (Sex == 1) set @title$, "Mister";
 
-    if (QL_CINDY == 4) goto L_Please_Visit;
+    if (QL_CINDY == 3) goto L_Please_Visit;
     if (QL_CINDY == 2) goto L_Reward;
-    if (QL_CINDY == 1) goto L_Please_Help;
+    if (QL_CINDY == 1 || QL_CINDY == 4 || QL_CINDY >= 7) goto L_Please_Help;
 
     mes "There is a little girl in a cage. As you come near, she starts to shiver and back off from you as far as she can in that small cage.";
     next;
@@ -43,6 +44,18 @@ L_Next:
         "Leave", L_Close;
 
 L_Try_Cage:
+    if (QL_CINDY >= 7) goto L_Failed;
+    if (QL_CINDY == 4) set @KEYS_AMOUNT, @KEYS_AMOUNT + @KEYS_REDO;
+    goto L_Try_Cage2;
+
+L_Failed:
+    mes "The yetis noticed you attempted to rescue their prisoner and reinforced the locks!";
+    set @KEYS_AMOUNT, @KEYS_AMOUNT * (QL_CINDY - 5);
+    mes "You will need " + @KEYS_AMOUNT + " keys to open the cage.";
+    next;
+    goto L_Try_Cage2;
+
+L_Try_Cage2:
     if (BaseLevel < @minlevel)
         goto L_To_Weak;
     if (countitem("TreasureKey") < @KEYS_AMOUNT)
@@ -51,6 +64,8 @@ L_Try_Cage:
     mes "As you try to open the door of the cage, there is a loud squeaking noise.";
     next;
     mes "You get an uncomfortable feeling and Cindy starts to shiver.";
+    if (QL_CINDY >= 7 && QL_CINDY < 16) set QL_CINDY, QL_CINDY + 1;
+    if (QL_CINDY == 1) set QL_CINDY, 7;
     if ($@FIGHT_YETI_STATUS != 0)
         goto L_Yeti;
     npctalk strnpcinfo(0), "Oh no, the Yetis...";
@@ -206,7 +221,7 @@ OnReward:
     set @bonus, (BaseLevel/2);
     set DailyQuestBonus, DailyQuestBonus + @bonus;
     message strcharinfo(0), "You feel a temporary rush of power and zest for action. " + @bonus + " daily bonus gained." ;
-    if (QL_CINDY != 1 )
+    if (QL_CINDY < 7)
         goto L_End;
     set QL_CINDY, 2;
     message strcharinfo(0), "Cindy looks relieved and as if she wants to talk with you.";


### PR DESCRIPTION
- Enable to re-do the cindy quest
- Prevent cindy "mules" by increasing the cost every time it is started so it becomes more economic to re-start the quest with a char that already finished it

for now let's merge this and later run a poll on the forums to ask what would be a fair cost to re-do the quest. let's keep it to 10 keys for now and ask their opinion
