### PR TITLE
Fix redoable Old Wizard Astral Skill scenario

### DIFF
--- a/world/map/npc/013-2/wizard.txt
+++ b/world/map/npc/013-2/wizard.txt
@@ -63,7 +63,7 @@ L_NewStudent:
     next;
 
     // check if the player has the knowledge of any skill
-    if ( (getskilllv(SKILL_POOL) && (getskilllv(SKILL_MAGIC_ASTRAL) < 1))
+    if (getskilllv(SKILL_POOL) && (getskilllv(SKILL_MAGIC_ASTRAL) < 1))
         menu
             "That would be very kind of you!", L_TeachSpell,
             "Actually I am looking for someone teaching me some more magic skills.", L_AstralSoul,

--- a/world/map/npc/013-2/wizard.txt
+++ b/world/map/npc/013-2/wizard.txt
@@ -63,7 +63,7 @@ L_NewStudent:
     next;
 
     // check if the player has the knowledge of any skill
-    if (getskilllv(SKILL_POOL))
+    if ( (getskilllv(SKILL_POOL) && (getskilllv(SKILL_MAGIC_ASTRAL) < 1))
         menu
             "That would be very kind of you!", L_TeachSpell,
             "Actually I am looking for someone teaching me some more magic skills.", L_AstralSoul,


### PR DESCRIPTION
This should make Old Wizard's Astral Soul teaching scenario not redoable.
At the moment requisites are being taken from player's inventory disregarding how many times this player has ran this scenario before.

Haven't tested that fix yet, but I guess you get the idea and can adjust the details if needed.
I thought a pull request is a better way of fixing this than a bug report. ;D