### PR TITLE
Fix golbenez script (turning in infinite amount of souls)

### DIFF
--- a/world/map/npc/027-2/golbenez.txt
+++ b/world/map/npc/027-2/golbenez.txt
@@ -319,10 +319,10 @@ L_Soul_Success:
     mes "Golbenez suddenly gets excited.";
     mes "[Golbenez]";
     mes "\"Yes! This one is full of energy.\"";
-    next;
-    mes "\"So be it, mortal. I will release Savaric's soul in exchange for this one.\"";
     set @state, 7;
     callsub S_Update_Mask;
+    next;
+    mes "\"So be it, mortal. I will release Savaric's soul in exchange for this one.\"";
     goto L_Close;
 
 L_Done:


### PR DESCRIPTION
When player is giving souls to Golbenez, at some point he gets the "right" soul. If he logs of at this point, then logs back in, the process can start over. This way, he can get 2000 XP infinite amount of times (as long as he has souls). The patch fixes it, by moving the state updating code before the "next;" command.