### PR TITLE
Don't remove towels from inventory on usage

### DIFF
--- a/world/map/npc/002-2/stranger.txt
+++ b/world/map/npc/002-2/stranger.txt
@@ -420,7 +420,6 @@ L_DeletePowder:
 
 L_DyeTowel:
     delitem @towelReq$[@towelCheckCount], 1;
-    callfunc "MultiWarpTowel";
     delitem "BottleOfWater", 1;
     getitem @warpTowelName$, 1;
     mes "He takes your towel, the water and the gem powder, then he turns away and does something you can't see. After a few minutes, he turns to you again.";

--- a/world/map/npc/functions/soul_menhir.txt
+++ b/world/map/npc/functions/soul_menhir.txt
@@ -11,7 +11,6 @@ function|script|SoulMenhir
 L_Towel:
     if (TowelLastUsed > (gettimetick(2) - 1800))
         goto L_DontPanic;
-    callfunc "MultiWarpTowel";
     set TowelLastUsed, gettimetick(2);
     mes "[Soul Menhir]";
     mes "(You touch the mysterious stone. Somehow it feels hard and soft at the same time.)";

--- a/world/map/npc/items/warpTowels.txt
+++ b/world/map/npc/items/warpTowels.txt
@@ -9,8 +9,6 @@ function|script|WarpTowel
     if (getmapflag(getmap(), MF_NOSAVE) || getmapflag(getmap(), MF_NOTELEPORT) || getmapflag(getmap(), MF_NOWARP) || isin("009-7",$@fightclub_x1,$@fightclub_y1,$@fightclub_x2,$@fightclub_y2))
         goto L_Forbid;
 
-    callfunc "MultiWarpTowel";
-
     if (@warpTowelName$ == "HitchhikersTowel")
         goto L_Save;
     if(@warpTowelName$ == "WhiteHitchhikersTowel")
@@ -152,28 +150,5 @@ L_End:
     set @NextLocationX, 0;
     set @NextLocationY, 0;
     set @warpTowelName$, "";
-    return;
-}
-
-function|script|MultiWarpTowel
-{
-    setarray $@warpTowels$, "HitchhikersTowel", "WhiteHitchhikersTowel", "RedHitchhikersTowel", "GreenHitchhikersTowel", "BlueHitchhikersTowel", "YellowHitchhikersTowel", "PurpleHitchhikersTowel", "OrangeHitchhikersTowel", "PinkHitchhikersTowel", "TealHitchhikersTowel", "LimeHitchhikersTowel";
-    set @towel_count, 0;
-    set @towel_loop, 0;
-    goto L_CountTowelLoop;
-
-L_CountTowelLoop:
-    set @towel_count, (@towel_count + countitem($@warpTowels$[@towel_loop]));
-    delitem $@warpTowels$[@towel_loop], countitem($@warpTowels$[@towel_loop]);
-    goto L_DelLoopAgain;
-
-L_DelLoopAgain:
-    if((@towel_loop + 1) == getarraysize($@warpTowels$))
-        goto L_Return;
-    set @towel_loop, (@towel_loop + 1);
-    goto L_CountTowelLoop;
-
-L_Return:
-    cleararray $@warpTowels$, "", getarraysize($@warpTowels$);
     return;
 }

--- a/world/map/npc/items/warpTowels.txt
+++ b/world/map/npc/items/warpTowels.txt
@@ -1,7 +1,7 @@
 // See #TravelConfig
 function|script|WarpTowel
 {
-    set @seconds, TowelLastUsed - (gettimetick(2) - 1800);
+    set @seconds, TowelLastUsed - (gettimetick(2) - 1200);
     if (@seconds > 0)
         goto L_DontPanic;
     if (isin("botcheck",25,27,51,47))


### PR DESCRIPTION
Due to https://forums.themanaworld.org/viewtopic.php?f=4&t=19395.

This fix prevents removing multiple towels from player's inventory, when you use one. You won't lose towels accidently anymore.