### PR TITLE
do not give a free stat reset to pre-tutorial players

### DIFF
--- a/world/map/npc/functions/headstyles.txt
+++ b/world/map/npc/functions/headstyles.txt
@@ -4,7 +4,7 @@
 function|script|fixHeadStyles
 {
     callfunc "getHeadStyles";
-    if ((TUT_var < 1 || QL_BEGIN < 1) && StatusPoint < 1)
+    if ((TUT_var < 1 || QL_BEGIN < 1) && StatusPoint < 1 && BaseLevel == 1)
         goto L_RandomHair; // on first login
     set @style, getlook(LOOK_HAIR_STYLE); // FIXME: this needs to be a param in the future
     set @color, getlook(LOOK_HAIR_COLOR); // FIXME: this needs to be a param in the future


### PR DESCRIPTION
the `((TUT_var < 1 || QL_BEGIN < 1) && StatusPoint < 1)` condition is intended to only be triggered by new players but it happens too for players that registered before the tutorial was introduced (`TUT_var` undefined) so they get a free stat reset *every time* they log in, until they read the game rules.. which is a Bad Thing™