### PR TITLE
Try deduction of Resist poison skill quest

### DIFF
--- a/world/map/npc/009-2/nurse.txt
+++ b/world/map/npc/009-2/nurse.txt
@@ -240,7 +240,6 @@ L_Exp_Game:
         "Alright.", L_Game;
 
 L_Game:
-    set @Q_poison, @Q_poison + 1;
     callsub S_Update_Var;
     // healing, venom, stabilizer
     callsub L_Load_Need;
@@ -330,6 +329,8 @@ L_choosePut:
     next;
     mes "You lift the glass to your lips and drink it all at once.";
     next;
+
+    set @Q_poison, @Q_poison + 1;
 
     if ( (@hlPut >  @hlNeed) && (@vnPut >  @vnNeed) )
         goto L_m_hl_m_vn;


### PR DESCRIPTION
While doing Resist Poison Skill quest, I lost a try because internet disconnected before the nurse could inject poison. So I think I pushed the try deduction to a later time.