### PR TITLE
make spells use mdef

### DIFF
--- a/world/map/npc/magic/_procedures.txt
+++ b/world/map/npc/magic/_procedures.txt
@@ -46,7 +46,7 @@ function|script|elt_damage
     set .@source, .caster;
     if (!.@source) set .@source, getcharid(3);
 
-    injure .@source, @target_id, .@dmg;
+    injure .@source, @target_id, (.@dmg * (100 - get(MDEF1, @target_id))) / 100;
     misceffect getarg(4), @target_id;
     return;
 }
@@ -56,7 +56,7 @@ function|script|melee_damage
     // args are spell power, target id, dmg
     if ((getarg(0) - rand(100)) < (get(BaseLevel, getarg(1)) + get(MDEF1, getarg(1))))
         injure BL_ID, getarg(1), 0;
-    else injure BL_ID, getarg(1), getarg(2);
+    else injure BL_ID, getarg(1), (getarg(2) * (100 - get(MDEF1, @target_id))) / 100;
     return;
 }
 

--- a/world/map/npc/magic/level2-rain.txt
+++ b/world/map/npc/magic/level2-rain.txt
@@ -86,7 +86,7 @@ OnHit:
     if(target(.caster, @target_id, 16) != 16 && .caster != @target_id) end;
     if((get(BL_TYPE, @target_id) & 1) == 0) end; // either mob or pc
     if(get(ELTTYPE, @target_id) == ELT_FIRE)
-        injure .caster, @target_id, rand((@spellpower/15)+5)+2;
+        injure .caster, @target_id, ((rand((@spellpower/15)+5)+2) * (100 - get(MDEF1, @target_id))) / 100;
     end;
 
 OnDestroy:


### PR DESCRIPTION
right now `#asorm` does nothing in PvP and spells bypass mdef of mobs