### PR TITLE
atcommand modifications

### DIFF
--- a/world/map/conf/permissions.txt
+++ b/world/map/conf/permissions.txt
@@ -12,6 +12,7 @@ CMD_WARP                40
 CMD_CHARWARP            60
 CMD_MUTE                60
 CMD_NPCTALK             40
+CMD_MUSIC               40
 
 // special permissions below
 MAP_LOUNGE              20  // level to enter the GM Lounge & talk to Numa

--- a/world/map/conf/permissions.txt
+++ b/world/map/conf/permissions.txt
@@ -11,6 +11,7 @@ CMD_REMOTECMD           40
 CMD_WARP                40
 CMD_CHARWARP            60
 CMD_MUTE                60
+CMD_NPCTALK             40
 
 // special permissions below
 MAP_LOUNGE              20  // level to enter the GM Lounge & talk to Numa

--- a/world/map/conf/permissions.txt
+++ b/world/map/conf/permissions.txt
@@ -10,6 +10,7 @@ CMD_DESTROYNPC          99
 CMD_REMOTECMD           40
 CMD_WARP                40
 CMD_CHARWARP            60
+CMD_MUTE                60
 
 // special permissions below
 MAP_LOUNGE              20  // level to enter the GM Lounge & talk to Numa

--- a/world/map/conf/permissions.txt
+++ b/world/map/conf/permissions.txt
@@ -8,6 +8,8 @@ CMD_CLASS               40
 CMD_CHARCLASS           50
 CMD_DESTROYNPC          99
 CMD_REMOTECMD           40
+CMD_WARP                40
+CMD_CHARWARP            60
 
 // special permissions below
 MAP_LOUNGE              20  // level to enter the GM Lounge & talk to Numa

--- a/world/map/conf/permissions_local.txt.example
+++ b/world/map/conf/permissions_local.txt.example
@@ -6,5 +6,6 @@
 //CMD_DEBUG               0
 //CMD_CHANGESEX           0
 //CMD_CLASS               0
+//CMD_WARP                0
 //MAP_LOUNGE              0
 //DBG_VALIA               0

--- a/world/map/db/params.txt
+++ b/world/map/db/params.txt
@@ -54,3 +54,7 @@ BL_TYPE                         1078 1
 CHAR_ID                         1079 1
 INVISIBLE                       1080 1
 HIDDEN                          1081 1
+MUTE_GLOBAL                     1082 1
+MUTE_WHISPER                    1083 1
+MUTE_PARTY                      1084 1
+//MUTE_GUILD                    1085 1

--- a/world/map/npc/commands/_import.txt
+++ b/world/map/npc/commands/_import.txt
@@ -12,3 +12,4 @@ npc: npc/commands/hug.txt
 npc: npc/commands/warp.txt
 npc: npc/commands/mute.txt
 npc: npc/commands/npctalk.txt
+npc: npc/commands/music.txt

--- a/world/map/npc/commands/_import.txt
+++ b/world/map/npc/commands/_import.txt
@@ -10,3 +10,4 @@ npc: npc/commands/destroynpc.txt
 npc: npc/commands/remotecmd.txt
 npc: npc/commands/hug.txt
 npc: npc/commands/warp.txt
+npc: npc/commands/mute.txt

--- a/world/map/npc/commands/_import.txt
+++ b/world/map/npc/commands/_import.txt
@@ -11,3 +11,4 @@ npc: npc/commands/remotecmd.txt
 npc: npc/commands/hug.txt
 npc: npc/commands/warp.txt
 npc: npc/commands/mute.txt
+npc: npc/commands/npctalk.txt

--- a/world/map/npc/commands/_import.txt
+++ b/world/map/npc/commands/_import.txt
@@ -9,3 +9,4 @@ npc: npc/commands/numa.txt
 npc: npc/commands/destroynpc.txt
 npc: npc/commands/remotecmd.txt
 npc: npc/commands/hug.txt
+npc: npc/commands/warp.txt

--- a/world/map/npc/commands/_procedures.txt
+++ b/world/map/npc/commands/_procedures.txt
@@ -8,6 +8,8 @@ function|script|argv_splitter
     set .@e, 0;
     set .@total, getarraysize(.@fragments$);
     set .@NULL$, chr(3); // HACK: we use .@NULL$ as a workaround because we can't do "\0"
+    cleararray @argv$[0], "", 20; // I don't think any atcommand will EVER need more than 20 args, and 20 is already generous
+    cleararray @argv[0], 0, 20;
     goto L_Check;
 
 L_Check:
@@ -49,5 +51,101 @@ L_CheckAfter:
     goto L_Check; // not done yet
 
 L_Done:
+    return;
+}
+
+// Map2Anchor
+// translates map aliases to actual maps
+function|script|map2anchor
+{
+    if (@map_anchor$[0] == "" && @argv$[0] != "")
+        set @map_anchor$[0], @argv$[0];
+
+    if (@map_anchor$[2] == "" && @argv[1] > 1 && @argv[2] > 1)
+        set @map_anchor$[1], @argv[1], @argv[2];
+
+    set .@a$, @map_anchor$[0]; // anchor name  // FIXME: I really want a str2lower() builtin
+
+    if (.@a$ == "hurnscald" || .@a$ == "hurn" || .@a$ == "hurns")
+        setarray @map_anchor$[0], "009-1", 55, 37;
+
+    elif (.@a$ == "nivalis" || .@a$ == "niv")
+        setarray @map_anchor$[0], "020-1", 74, 83;
+
+    elif (.@a$ == "tulimshar" || .@a$ == "tulim" || .@a$ == "tul")
+        setarray @map_anchor$[0], "001-1", 64, 101;
+
+    elif (.@a$ == "candor" || .@a$ == "newbington" || .@a$ == "noob")
+        setarray @map_anchor$[0], "029-1", 52, 93;
+
+    elif (.@a$ == "oldwizard" || .@a$ == "wizard" || .@a$ == "oldwiz")
+        setarray @map_anchor$[0], "013-1", 41, 92;
+
+    elif (.@a$ == "desert" || .@a$ == "pachua")
+        setarray @map_anchor$[0], "006-1", 34, 99;
+
+    elif (.@a$ == "forest" || .@a$ == "katze")
+        setarray @map_anchor$[0], "015-1", 58, 35;
+
+    elif (.@a$ == "dimond" || .@a$ == "dimondscove")
+        setarray @map_anchor$[0], "010-2", 31, 39;
+
+    elif (.@a$ == "asphodel" || .@a$ == "swamp" || .@a$ == "swampvillage" || .@a$ == "undeadtown")
+        setarray @map_anchor$[0], "026-1", 32, 33;
+
+    elif (.@a$ == "gy" || .@a$ == "graveyard")
+        setarray @map_anchor$[0], "027-1", 71, 87;
+
+    elif (.@a$ == "krukan" || .@a$ == "generalkrukan")
+        setarray @map_anchor$[0], "027-6", 39, 47;
+
+    elif (.@a$ == "razha" || .@a$ == "generalrazha")
+        setarray @map_anchor$[0], "027-7", 39, 35;
+
+    elif (.@a$ == "terogan" || .@a$ == "generalterogan")
+        setarray @map_anchor$[0], "027-8", 39, 52;
+
+    elif (.@a$ == "gmisland" || .@a$ == "eventisland" || .@a$ == "easterisland" || .@a$ == "island")
+        setarray @map_anchor$[0], "028-1", 99, 40;
+
+    elif (.@a$ == "auditorium" || .@a$ == "scene")
+        setarray @map_anchor$[0], "028-1", 119, 69;
+
+    elif (.@a$ == "theater")
+        setarray @map_anchor$[0], "017-2", 26, 23;
+
+    elif (.@a$ == "lounge" || .@a$ == "gmlounge" || .@a$ == "gm" || .@a$ == "backstage")
+        setarray @map_anchor$[0], "017-9", 26, 23;
+
+    elif (.@a$ == "cindy" || .@a$ == "cindycave")
+        setarray @map_anchor$[0], "031-3", 47, 26;
+
+    elif (.@a$ == "terranite" || .@a$ == "terra" || .@a$ == "terracave")
+        setarray @map_anchor$[0], "012-3", 448, 65;
+
+    elif (.@a$ == "terranitesafe" || .@a$ == "terrasafe" || .@a$ == "safeterra")
+        setarray @map_anchor$[0], "012-4", 473, 184;
+
+    elif (.@a$ == "bluesage" || .@a$ == "blue")
+        setarray @map_anchor$[0], "048-2", 40, 46;
+
+    elif (.@a$ == "xmasinn" || .@a$ == "xmas")
+        setarray @map_anchor$[0], "030-2", 85, 46;
+
+    elif (.@a$ == "barbarians" || .@a$ == "barbarian" || .@a$ == "fluffy")
+        setarray @map_anchor$[0], "033-1", 71, 33;
+
+    elif (.@a$ == "park" || .@a$ == "porttown" || .@a$ == "farms")
+        setarray @map_anchor$[0], "057-1", 100, 77;
+
+    elif (.@a$ == "hills" || .@a$ == "orum")
+        setarray @map_anchor$[0], "017-1", 112, 49;
+
+    elif (.@a$ == "batcave" || .@a$ == "bat")
+        setarray @map_anchor$[0], "011-3", 30, 26;
+
+    else
+        set @map_anchor$[3], "no"; // did not use an anchor
+
     return;
 }

--- a/world/map/npc/commands/music.txt
+++ b/world/map/npc/commands/music.txt
@@ -1,0 +1,34 @@
+-|script|@music|32767
+{
+    callfunc "argv_splitter";
+    if (GM < CMD_MUSIC && GM < G_SYSOP) goto L_GM;
+    if (@argv$[0] == "") goto L_Failed;
+
+    gmlog "@music " + @args$;
+    set .@find, array_search(@argv$[0], .find$);
+    if (.@find >= 0)
+        set @argv$[0], .replace$[max(.@find, 0)];
+    set .file$, @argv$[0];
+    areatimer 0, getmap(), (POS_X - .range), (POS_Y - .range), (POS_X + .range), (POS_Y + .range), 0, strnpcinfo(0)+"::OnPC";
+    message strcharinfo(0), "music : The music has ben temporarily changed.";
+    end;
+
+OnPC:
+    music .file$ + ".ogg";
+    end;
+
+L_Failed:
+    message strcharinfo(0), "music : You must specify a music file.";
+    end;
+
+L_GM:
+    message strcharinfo(0), "music : GM command is level "+ CMD_MUSIC +", but you are level " + GM;
+    end;
+
+OnInit:
+    setarray .find$, "this", "cave", "chilling", "clouds", "dimond", "explorers", "gy", "reid", "magick", "mystique", "night", "ride", "sail", "snow", "forest", "xmas";
+    setarray .replace$, "this", "cavesong", "chilling-environment", "clouds-calling", "dimonds-cove", "explorers-melody", "graveyard", "inquisitive-inn", "magick-real", "mystique-forest", "night-is-calling", "ride-of-the-valkyries", "sail-away", "snow-village", "the-forest", "white-christmas";
+    set .range, 14; // FIXME: make this a const
+    registercmd chr(ATCMD_SYMBOL) + "music", strnpcinfo(0);
+    end;
+}

--- a/world/map/npc/commands/mute.txt
+++ b/world/map/npc/commands/mute.txt
@@ -45,10 +45,18 @@ OnSTFUPC:
 OnPCLoginEvent:
     if (#MUTE_UNTIL < 1) end;
     set .@s, (#MUTE_UNTIL - gettimetick(2));
+    if (.@s < 5) goto L_ClearMute;
     set .@m, .@s / 60;
     message strcharinfo(0), "Server : ##BYou have been muted for "+ max(1, .@m) +" minutes.";
     set MUTE_GLOBAL, 1;
     addtimer (.@s * 1000) + 100, strnpcinfo(0) + "::OnCheckMute";
+    end;
+
+L_ClearMute:
+    message strcharinfo(0), "Server : ##BYour mute has expired while you were away. You have been automatically unmuted.";
+    if ((#MUTE_UNTIL - gettimetick(2)) >= (0 - 900))
+        wgm "=> Player `"+ strcharinfo(0) +"` has been automatically unmuted."; // only send if unmuted 15 minutes ago or less
+    set #MUTE_UNTIL, 0;
     end;
 
 OnCheckMute:

--- a/world/map/npc/commands/mute.txt
+++ b/world/map/npc/commands/mute.txt
@@ -1,0 +1,60 @@
+-|script|@mute|32767
+{
+    callfunc "argv_splitter";
+    if (GM < CMD_MUTE && GM < G_SYSOP) goto L_GM;
+    if (@argv$[1] == "") goto L_Failed;
+
+    set .@target_id, getcharid(3, @argv$[1]);
+    if (.@target_id < 1 || !(isloggedin(.@target_id))) goto L_Failed;
+
+    if (@argv[0] > 120)
+        set @argv[0], 120; // max 2 hours
+
+    gmlog "@mute " + @args$;
+    if (@argv[0] == 0) goto L_UnMute;
+
+    message strcharinfo(0, .@target_id), "Server : ##BYou have been muted by a GM for "+@argv[0]+" minutes.";
+    set MUTE_GLOBAL, 1, .@target_id;
+    set #MUTE_UNTIL, (gettimetick(2) + (@argv[0] * 60)), .@target_id;
+    addtimer (@argv[0] * 60000) + 100, strnpcinfo(0) + "::OnCheckMute", .@target_id;
+    message strcharinfo(0), "mute : Player `"+strcharinfo(0, .@target_id)+"` has been muted for "+@argv[0]+" minutes.";
+    end;
+
+OnPCLoginEvent:
+    if (#MUTE_UNTIL < 1) end;
+    set .@s, (#MUTE_UNTIL - gettimetick(2));
+    set .@m, .@s / 60;
+    message strcharinfo(0), "Server : ##BYou have been muted for "+ max(1, .@m) +" minutes.";
+    set MUTE_GLOBAL, 1;
+    addtimer (.@s * 1000) + 100, strnpcinfo(0) + "::OnCheckMute";
+    end;
+
+OnCheckMute:
+    if (#MUTE_UNTIL < 1) end;
+    if (gettimetick(2) - #MUTE_UNTIL < 0) end;
+    message strcharinfo(0), "Server : ##BYou have been automatically unmuted.";
+    wgm "=> Player `"+ strcharinfo(0) +"` has been automatically unmuted.";
+    set MUTE_GLOBAL, 0;
+    set #MUTE_UNTIL, 0;
+    end;
+
+L_UnMute:
+    if (get(MUTE_GLOBAL, .@target_id))
+        message strcharinfo(0, .@target_id), "Server : ##BYou have been unmuted by a GM.";
+    set MUTE_GLOBAL, 0, .@target_id;
+    set #MUTE_UNTIL, 0, .@target_id;
+    message strcharinfo(0), "mute : Player `"+strcharinfo(0, .@target_id)+"` has been unmuted.";
+    end;
+
+L_Failed:
+    message strcharinfo(0), "mute : Impossible to attach to the target player. Did you try putting the name in \"quotation marks\"?";
+    end;
+
+L_GM:
+    message strcharinfo(0), "mute : GM command is level "+ CMD_MUTE +", but you are level " + GM;
+    end;
+
+OnInit:
+    registercmd chr(ATCMD_SYMBOL) + "mute", strnpcinfo(0);
+    end;
+}

--- a/world/map/npc/commands/mute.txt
+++ b/world/map/npc/commands/mute.txt
@@ -20,6 +20,28 @@
     message strcharinfo(0), "mute : Player `"+strcharinfo(0, .@target_id)+"` has been muted for "+@argv[0]+" minutes.";
     end;
 
+OnSTFU:
+    if (GM < CMD_MUTE && GM < G_SYSOP) goto L_GM;
+    callfunc "argv_splitter";
+    if (@argv[0] < 1) set @argv[0], 1;
+    if (@argv[0] > 10) set @argv[0], 10;
+    gmlog "@stfu " + @argv[0];
+    set @stfu_nr, 0;
+    foreach 0, getmap(), (POS_X - .range), (POS_Y - .range), (POS_X + .range), (POS_Y + .range), strnpcinfo(0)+"::OnSTFUPC";
+    message strcharinfo(0), "mute : Every player within "+.range+" tiles have been muted for "+@argv[0]+" minutes. ["+@stfu_nr+"]";
+    set @stfu_nr, 0;
+    end;
+
+OnSTFUPC:
+    if (@target_id == BL_ID) end;
+    set .@future, (gettimetick(2) + (@argv[0] * 60));
+    if (get(#MUTE_UNTIL, @target_id) > .@future) end; // if player already has a mute, don't reduce it
+    set MUTE_GLOBAL, 1, @target_id;
+    set #MUTE_UNTIL, .@future, @target_id;
+    addtimer (@argv[0] * 60000) + 100, strnpcinfo(0) + "::OnCheckMute", @target_id;
+    set @stfu_nr, @stfu_nr + 1;
+    end;
+
 OnPCLoginEvent:
     if (#MUTE_UNTIL < 1) end;
     set .@s, (#MUTE_UNTIL - gettimetick(2));
@@ -55,6 +77,9 @@ L_GM:
     end;
 
 OnInit:
+    set .range, 14; // FIXME: this should be a const
     registercmd chr(ATCMD_SYMBOL) + "mute", strnpcinfo(0);
+    registercmd chr(ATCMD_SYMBOL) + "stfu", strnpcinfo(0) + "::OnSTFU";
+    registercmd chr(ATCMD_SYMBOL) + "areamute", strnpcinfo(0) + "::OnSTFU"; // alias of STFU
     end;
 }

--- a/world/map/npc/commands/npctalk.txt
+++ b/world/map/npc/commands/npctalk.txt
@@ -1,0 +1,23 @@
+-|script|@npctalk|32767
+{
+    callfunc "argv_splitter";
+    if (GM < CMD_NPCTALK && GM < G_SYSOP) goto L_GM;
+    if (@argv$[0] == "" || @argv$[1] == "") goto L_Failed;
+    if (getnpcid(@argv$[0]) < 1) goto L_Failed;
+
+    gmlog "@npctalk " + @args$;
+    npctalk @argv$[0], @argv$[1];
+    end;
+
+L_Failed:
+    message strcharinfo(0), "npctalk : Impossible to attach to the target npc. Did you try putting the name in \"quotation marks\"?";
+    end;
+
+L_GM:
+    message strcharinfo(0), "npctalk : GM command is level "+ CMD_NPCTALK +", but you are level " + GM;
+    end;
+
+OnInit:
+    registercmd chr(ATCMD_SYMBOL) + "npctalk", strnpcinfo(0);
+    end;
+}

--- a/world/map/npc/commands/warp.txt
+++ b/world/map/npc/commands/warp.txt
@@ -1,0 +1,57 @@
+-|script|@warp|32767
+{
+    callfunc "argv_splitter";
+    if (@argv$[3] == "" && @argv$[2] == "" && @argv$[1] != "" && @argv[1] < 2)
+        set @argv$[3], @argv$[1];
+
+    set .@n$, if_then_else(@argv$[3] != "", "char", "") + "warp";
+    if (GM < CMD_WARP && GM < G_SYSOP) goto L_GM; // check if you can use it on self
+    set .@target_id, BL_ID;
+    if (@argv$[3] != "") set .@target_id, getcharid(3, @argv$[3]);
+    if (@argv$[3] != "" && !(isloggedin(.@target_id))) goto L_Failed; // do NOT fallback to self
+    if (@argv$[3] != "" && GM < CMD_CHARWARP && GM < G_SYSOP) goto L_GM; // when target is not self, use charwarp permission
+
+    if (@argv$[0] == "")
+        set @argv$[0], getmap();
+
+    setarray @map_anchor$[0], "", "", "", "";
+    callfunc "map2anchor";
+
+    gmlog "@"+.@n$+" " + @args$;
+    if (.@target_id != BL_ID)
+        message strcharinfo(0), .@n$+" : The operation succeeded.";
+
+    set @GMWARP_map$, @map_anchor$[0];
+    set @GMWARP_x, if_then_else(@argv[1] > 1, @argv[1], @map_anchor$[1]);
+    set @GMWARP_y, if_then_else(@argv[2] > 1, @argv[2], @map_anchor$[2]);
+    addtimer 0, strnpcinfo(0) + "::OnWarp", .@target_id;
+
+    if (@map_anchor$[3] == "no" && @knows_anchors < 1)
+        goto L_SuggestAnchors;
+    end;
+
+L_SuggestAnchors:
+    message strcharinfo(0), .@n$+" : The warp command has been improved. You might want to consider using [@@https://www.themanaworld.org/index.php/Dev:GM_Commands/anchors|map anchors@@].";
+    set @knows_anchors, 1;
+    end;
+
+OnWarp:
+    warp @GMWARP_map$, @GMWARP_x, @GMWARP_y;
+    set @GMWARP_map$, "";
+    set @GMWARP_x, 0;
+    set @GMWARP_y, 0;
+    end;
+
+L_Failed:
+    message strcharinfo(0), .@n$+" : Impossible to attach to the target player. Did you try putting the name in \"quotation marks\"?";
+    end;
+
+L_GM:
+    message strcharinfo(0), .@n$+" : GM command is level "+ if_then_else(@argv$[1] != "", CMD_CHARWARP, CMD_WARP) +", but you are level " + GM;
+    end;
+
+OnInit:
+    registercmd chr(ATCMD_SYMBOL) + "warp", strnpcinfo(0);
+    registercmd chr(ATCMD_SYMBOL) + "charwarp", strnpcinfo(0);
+    end;
+}


### PR DESCRIPTION
allows GMs to do that kind of thing:
- `@warp hurnscald`
  - warps to `009-1, 55, 37`
- `@warp hurnscald 45 32`
  - warps to `009-1, 45, 32`
- `@warp 009-1`
  - warps to `009-1, 0, 0` (random location)
- `@warp 009-1 45 32`
  - warps to `009-1, 45, 32`

also works for `@charwarp`

---
also adds `@mute`
## requires https://github.com/themanaworld/tmwa/pull/220