### PR TITLE
call QuestTreeTrigger when player *hugs tree*

### DIFF
--- a/world/map/npc/commands/hug.txt
+++ b/world/map/npc/commands/hug.txt
@@ -13,7 +13,8 @@
     if (@target_id != BL_ID) misceffect FX_HUG, @target_id;
 
     if (@target_id != .tree_id) end;
-    callfunc "QuestTreeTouch";
+    set @flag, 2;
+    callfunc "QuestTreeTrigger";
     close;
 
 OnInit:


### PR DESCRIPTION
Seems the wrong function was called when the player *hugs tree*.