### PR TITLE
replace SCRIPT_XP with MAGIC_EXPERIENCE in gain_heal_xp

### DIFF
--- a/world/map/npc/magic/_procedures.txt
+++ b/world/map/npc/magic/_procedures.txt
@@ -169,7 +169,7 @@ L_Return:
 function|script|gain_heal_xp
 {
     set @last_heal_xp, ((MAGIC_EXPERIENCE & SCRIPT_HEALSPELL_MASK) >>  SCRIPT_HEALSPELL_SHIFT);
-    if ((@target_id != BL_ID) && ((.@heal_value / .heal_xp_value_divisor) > (((10 + @last_heal_xp) + rand(@last_heal_xp + 1)) + rand(@last_heal_xp + 1))))
+    if ((@target_id != BL_ID) && ((@heal_value / .heal_xp_value_divisor) > (((10 + @last_heal_xp) + rand(@last_heal_xp + 1)) + rand(@last_heal_xp + 1))))
         goto L_Block;
     goto L_Return;
 
@@ -181,8 +181,8 @@ L_Block:
     goto L_Gain_Xp;
 
 L_Gain_Xp:
-    set @heal_exp, .@heal_value;
-    if (.@heal_value > get(HEALXP, @target_id))
+    set @heal_exp, @heal_value;
+    if (@heal_value > get(HEALXP, @target_id))
         set @heal_exp, get(HEALXP, @target_id);
     getexp (.base_exp_factor * @heal_exp), 0;
     goto L_Return;

--- a/world/map/npc/magic/_procedures.txt
+++ b/world/map/npc/magic/_procedures.txt
@@ -168,7 +168,7 @@ L_Return:
 
 function|script|gain_heal_xp
 {
-    set @last_heal_xp, ((SCRIPT_XP & SCRIPT_HEALSPELL_MASK) >>  SCRIPT_HEALSPELL_SHIFT);
+    set @last_heal_xp, ((MAGIC_EXPERIENCE & SCRIPT_HEALSPELL_MASK) >>  SCRIPT_HEALSPELL_SHIFT);
     if ((@target_id != BL_ID) && ((.@heal_value / .heal_xp_value_divisor) > (((10 + @last_heal_xp) + rand(@last_heal_xp + 1)) + rand(@last_heal_xp + 1))))
         goto L_Block;
     goto L_Return;
@@ -177,7 +177,7 @@ L_Block:
     set @heal_xp, (@last_heal_xp + @mexp);
     if (@heal_xp > SCRIPT_HEALSPELL_MASK)
         set @heal_xp, SCRIPT_HEALSPELL_MASK;
-    set SCRIPT_XP, (SCRIPT_XP & ~(SCRIPT_HEALSPELL_MASK) | (@heal_xp << SCRIPT_HEALSPELL_SHIFT));
+    set MAGIC_EXPERIENCE, (MAGIC_EXPERIENCE & ~(SCRIPT_HEALSPELL_MASK) | (@heal_xp << SCRIPT_HEALSPELL_SHIFT));
     goto L_Gain_Xp;
 
 L_Gain_Xp:

--- a/world/map/npc/magic/level1-lesser-heal.txt
+++ b/world/map/npc/magic/level1-lesser-heal.txt
@@ -17,11 +17,11 @@
     callfunc "adjust_spellpower";
     set Sp, Sp - 6;
     misceffect FX_MAGIC_WHITE, strcharinfo(0);
-    set .@heal_value, get(HEALXP, @target_id);
+    set @heal_value, get(HEALXP, @target_id);
     set @mexp, .exp_gain;
     callfunc "magic_exp";
-    if (.@heal_value > 200)
-        set .@heal_value, 200;
+    if (@heal_value > 200)
+        set @heal_value, 200;
     if (@args$ == "Mouboo" || @args$ == "mouboo") goto L_Mouboo;
     if (@target_id != BL_ID) goto L_NotMe;
     goto L_Continue;

--- a/world/map/npc/magic/level2-lay-on-hands.txt
+++ b/world/map/npc/magic/level2-lay-on-hands.txt
@@ -25,7 +25,7 @@ L_Pay:
     set .@fraction, max(80, 200 - (Vit + (@spellpower/10))); // pay at least 40%
     set .@payment, (.@needed * .@fraction) / 200;
     set .@available, Hp - (MaxHp / 20);
-    set .@heal_value, if_then_else(.@payment < .@available, .@needed+1-1, (.@available * 200) / .@fraction); // FIXME / XXX why the f do I need to do +1-1 ?
+    set @heal_value, if_then_else(.@payment < .@available, .@needed+1-1, (.@available * 200) / .@fraction); // FIXME / XXX why the f do I need to do +1-1 ?
     if (.@payment > .@available) set .@payment, .@available;
 
 
@@ -40,7 +40,7 @@ L_Pay:
 
     set .@thp, get(Hp, @target_id);
     if (.@thp < 1) end;
-    set Hp, .@thp + .@heal_value, @target_id;
+    set Hp, .@thp + @heal_value, @target_id;
     end;
 
 L_Mouboo:


### PR DESCRIPTION
For some reason in gain_heal_xp a mysterious variable SCRIPT_XP is being used (maybe it was supposed to be an alias to MAGIC_EXPERIENCE?), this variable isn't met anywhere else.

This should fix gaining healing experience (needed for Elanore).
