### PR TITLE
Fix a possible bug when casting @showgm (or @hidegm) twice (if admin)

### DIFF
--- a/world/map/npc/commands/gm.txt
+++ b/world/map/npc/commands/gm.txt
@@ -5,7 +5,7 @@
 OnHide:
     if (GM < 10 && GM < G_SYSOP) end;
 
-    if (GM == 99) set GM, 98;
+    if (GM >= 98) set GM, 98;
     else set GM, (GM - (GM % 10)) + 1;
 
     message strcharinfo(0), "hidelevel : Your GM level is now hidden.";
@@ -14,7 +14,7 @@ OnHide:
 OnShow:
     if (GM < 10 && GM < G_SYSOP) end;
 
-    if (GM == 98) set GM, 99;
+    if (GM >= 98) set GM, 99;
     else set GM, GM - (GM % 10);
 
     message strcharinfo(0), "showlevel : Your GM level is now visible.";


### PR DESCRIPTION
Only admins can be affected by this bug.

It looks inefficient code-wise but is simpler than making additional checks if you should be using the command or not. (There's no issue in setting your GM level to itself AFAIK)