### PR TITLE
Add to @numa Quest Debug options to change Candor Battle difficulty.

### DIFF
--- a/world/map/npc/029-3/parua.txt
+++ b/world/map/npc/029-3/parua.txt
@@ -211,7 +211,7 @@ L_NextRound:
         set $@FIGHT_CAVE_TEMP_UP, 100;
 
     set $@FIGHT_CAVE_LEVEL, $@FIGHT_CAVE_LEVEL + $@FIGHT_CAVE_PLAYER_COUNT + $@FIGHT_CAVE_TEMP_UP;
-    if ($@FIGHT_CAVE_LEVEL >= 2200)
+    if ($@FIGHT_CAVE_LEVEL >= $@FIGHT_CAVE_MAX_LEVEL)
         goto L_CleanUp;
     set $@FIGHT_CAVE_POINTS, $@FIGHT_CAVE_LEVEL;
 
@@ -404,4 +404,38 @@ OnReward:
     set BOSS_POINTS, BOSS_POINTS + 100;
     message strcharinfo(0), "You gain 100 Boss Points giving you a total of " + BOSS_POINTS + ".";
     goto L_CleanUp_Player;
+}
+
+function|script|CandorDebug
+{
+    mes "$@FIGHT_CAVE_MAX_LEVEL: "+$@FIGHT_CAVE_MAX_LEVEL;
+    mes "---";
+	next;
+	// NORMAL is listed twice.
+	menu
+		"Set to NORMAL difficulty (2200)", L_Normal,
+		"Set to HARD difficulty (3300, for events)", L_Hard,
+		"Set to EXPERT difficulty (4500, for events)", L_Expert,
+		"Set to EASY difficulty (1800, for events)", L_Easy,
+		"Set to NORMAL difficulty (2200)", L_Normal;
+
+L_Normal:
+	set $@FIGHT_CAVE_MAX_LEVEL, 2200;
+    gmlog strcharinfo(0) + " restored Candor Difficulty to normal.";
+    return;
+
+L_Easy:
+	set $@FIGHT_CAVE_MAX_LEVEL, 1800;
+    gmlog strcharinfo(0) + " has set Candor Difficulty to EASY.";
+    return;
+
+L_Hard:
+	set $@FIGHT_CAVE_MAX_LEVEL, 3300;
+    gmlog strcharinfo(0) + " has set Candor Difficulty to HARD.";
+    return;
+
+L_Expert:
+	set $@FIGHT_CAVE_MAX_LEVEL, 4500;
+    gmlog strcharinfo(0) + " has set Candor Difficulty to EXPERT.";
+    return;
 }

--- a/world/map/npc/commands/numa.txt
+++ b/world/map/npc/commands/numa.txt
@@ -91,6 +91,8 @@ OnInit:
     registercmd chr(ATCMD_SYMBOL) + "numa", strnpcinfo(0);
     registercmd chr(ATCMD_SYMBOL) + "superdebug", strnpcinfo(0);
     if (puppet("017-9", 30, 28, "Numa", 393) < 1) mapexit;
+    if(!($@FIGHT_CAVE_MAX_LEVEL))
+        set $@FIGHT_CAVE_MAX_LEVEL, 2200;
     end;
 }
 
@@ -119,6 +121,7 @@ L_Woodland:
     next;
     menu
         "Illia Sisters", L_Valia,
+        "Candor Battle", L_Candor,
         "Choose an area", L_Argeas,
         "Close", L_Return;
 
@@ -146,5 +149,9 @@ L_Doomsday:
 
 L_Fluffy:
     callfunc "FluffyDebug";
+    goto L_Return;
+
+L_Candor:
+    callfunc "CandorDebug";
     goto L_Return;
 }


### PR DESCRIPTION
Now features four difficulties: Easy (1800) Normal (2200) Hard (3300) and Expert (4500).

Do not use Expert unless you know what you are doing.

These settings are meant for events only; The only way to revert is by Numa or a server restart.

The rewards are always the same regardless of difficulty setting.

There's no option to change minimum players to begin a Candor Fight, because I didn't deem that to be necessary; Not like there would be an event with < 5 people online.

This feature was added having Revival Candor event in mind; In an Hercules-based server this workaround could be easily replaced with `@set` >.>

Note: Please keep in mind I'm not using an input() on purpose - I don't remember if we can limit the minimum and maximum value on TMWA. Every 100 points is roughly an extra wave. This setting WILL persist accross challenges, so REMEMBER to restore it after the event or you'll listen complains >.>

Adding an extra menu which only shows up to GMs is also an option.