### PR TITLE
fix magic_exp not updating last used spell index

### DIFF
--- a/world/map/npc/magic/_procedures.txt
+++ b/world/map/npc/magic/_procedures.txt
@@ -149,6 +149,7 @@ function|script|magic_exp
     goto L_Return;
 
 L_Gain:
+    set MAGIC_EXPERIENCE, call("bit", MAGIC_EXPERIENCE, 0xFF, 16, .index);
     if(.exp_gain < 1) goto L_Return; // only the spells that have exp register here. If you
     //                                 remove this line then players can cast a spell with
     //                                 no cost, then a spell with a reagents, then another
@@ -157,7 +158,6 @@ L_Gain:
     //debugmes "old magic exp: "+ @last_exp;
     //debugmes "new magic exp: "+ @new_exp;
     set MAGIC_EXPERIENCE, call("bit", MAGIC_EXPERIENCE, 0xFFFF, 0, @new_exp);
-    set MAGIC_EXPERIENCE, call("bit", MAGIC_EXPERIENCE, 0xFF, 16, .index);
     goto L_Return;
 
 L_Return:


### PR DESCRIPTION
I've noticed that casting #plugh and #miteyo alternately did not update #abizit message after more than 150 #plugh casts. I've found that it is due to magic_exp function returning without updating last used spell index for spells with zero exp_gain.

If this behavior is intended and one is not allowed to level up magic repeating spells with zero and non-zero cost, please leave a comment and close this PR :)