### PR TITLE
Halloween 2020

### DIFF
--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -81,7 +81,6 @@ L_Main:
 
     // Done
     set $@UnderMc, 0;
-    set $@TulimMc, 0;
     end;
 
 // Labels
@@ -135,71 +134,284 @@ OnInit:
 003-1,44,40,0|script|#HW2020Bazar|424,0,0
 {
     close;
+
+OnTouch:
+
+    // BOSS: 1073 The Lost
+
+    end;
+
+OnInit:
+    disablenpc "#HW2020Bazar";
+    end;
+}
+
+////////////////////////////////////////////////
+// Hocus Campaign Main Function
+// HocusCampaign( @JACKOID )
+// Use getmap(), getx() and gety() for spawn centering
+// OnBegin:
+// $@HW2020_SLAIN[ JACKOID ] = False
+// $@HW2020_TIMER[ JACKOID ] = gettimetick(2)
+// Have HW2020 Mobs timer controlling all of them (runs every minute for expire)
+// OnFinish:
+// $@HW2020_SLAIN[ JACKOID ] = True
+// Timer NOT updated!!
+function|script|HocusCampaign
+{
+    if (@JACKOID < 1)
+        goto L_Return;
+
+    if ($@HW2020_TIMER[@JACKOID] > gettimetick(2))
+        goto L_Check;
+
+    mes "[Jack O]";
+    mes "Hohoho... I am the JackO who curses this lost soul.";
+    mes "Do you want to free this person? Defeat meeeeee....";
+    next;
+    mes "[Jack O]";
+    mes "Hohoho... Prove your worth, defeat meeeeee....";
+    mes "Slay all my minions, can you prove yourself to meeeeee....?";
+    next;
+    mes "##3.:: Mission Goals ::.##0";
+    mes "1. Defeat all monsters spawned by JackO";
+    mes "2. Talk to JackO after this to lift the curse";
+    mes "3. Once all 13 NPCs curse is lifted, go to the Bazar.";
+    mes "";
+    mes "##1Time Limit: 1 hour since first JackO monster spawn.";
+    next;
+    menu
+        "Bring it on!", L_Begin,
+        "Not now!", L_Abort;
+
+L_Begin:
+    set @JACKOID, @JACKOID-1;
+    if ($@HW2020_TIMER[@JACKOID] > gettimetick(2))
+        goto L_Return;
+
+    // Assign timer, set JackO to ACTIVE
+    set $@HW2020_SLAIN[@JACKOID], 0;
+    set $@HW2020_TIMER[@JACKOID], gettimetick(2)+3600;
+
+    // Define mob id
+    if (@JACKOID % 8 == 0)
+        set @mobID, 1096; // Soul Snake
+    if (@JACKOID % 8 == 1)
+        set @mobID, 1036; // Zombie
+    if (@JACKOID % 8 == 2)
+        set @mobID, 1103; // Witch Guard
+    if (@JACKOID % 8 == 3)
+        set @mobID, 1045; // Fallen
+    if (@JACKOID % 8 == 4)
+        set @mobID, 1022; // JackO
+    if (@JACKOID % 8 == 5)
+        set @mobID, 1075; // Stalker
+    if (@JACKOID % 8 == 6)
+        set @mobID, 1074; // Red Bone
+    if (@JACKOID % 8 == 7)
+        set @mobID, 1124; // Wight
+
+    // Define mob amound
+        set @mobAM, 8; // Zombie
+    if (@JACKOID % 8 == 0)
+        set @mobAM, 12; // Soul Snake must be more
+    if (@JACKOID % 8 >= 4)
+        set @mobAM, 6; // Stalker, JackO, Red and Wigh must be less
+
+    // Spawn the Monsters
+    areamonster "003-1", getx()-10, gety()-10, getx()+10, gety()+10, "", @mobID, @mobAM, "HW2020 Mobs::OnDeath"+(@JACKOID+1);
+
+    // Announce
+     mapannounce "003-1", "JackO : Hohoho... You cannot defeat me1" , 0;
+
+    // Clear temporary variables
+    set @mobID, 0;
+    set @mobAM, 0;
+    close2;
+    return;
+
+L_Abort:
+    close2;
+    return;
+
+L_Check:
+    // Count Monsters
+    set @TulimMc, mobcount("003-1", "HW2020 Mobs::OnDeath"+(@JACKOID+1))+1;
+    if (@TulimMc)
+        goto L_Information;
+
+    // Disable JackO here, the script will catch that
+    set $@HW2020_SLAIN[@JACKOID], 1;
+
+    mes "[JackO]";
+    mes "Hohoho... We'll meet againnnnnnnn!";
+    close2;
+    return;
+
+L_Information:
+    message strcharinfo(0), "JackO : Hohoho... Still "+@TulimMC+" monsters alive... Defeat meeeeee.....!";
+    return;
+
+L_Return:
+    return;
+
 }
 
 ////////////////////////////////////////////////
 // JackOs (13 JackOs)
-003-1,26,73,0|script|JackO#Tybalt|184
+003-1,26,73,0|script|JackO#Tybalt|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 1;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,101,31,0|script|JackO#Nicolas|184
+003-1,101,31,0|script|JackO#Nicolas|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 2;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,38,66,0|script|JackO#Elanore|184
+003-1,38,66,0|script|JackO#Elanore|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 3;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,56,70,0|script|JackO#Aisha|184
+003-1,56,70,0|script|JackO#Aisha|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 4;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,119,33,0|script|JackO#Nina|184
+003-1,119,33,0|script|JackO#Nina|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 5;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,32,30,0|script|JackO#Ian|184
+003-1,32,30,0|script|JackO#Ian|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 6;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,113,43,0|script|JackO#Luca|184
+003-1,113,43,0|script|JackO#Luca|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 7;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,47,79,0|script|JackO#Ekinu|184
+003-1,47,79,0|script|JackO#Ekinu|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 8;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,38,79,0|script|JackO#Ryan|184
+003-1,38,79,0|script|JackO#Ryan|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 9;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,53,45,0|script|JackO#Neko|184
+003-1,53,45,0|script|JackO#Neko|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 10;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,54,51,0|script|JackO#Ishi|184
+003-1,54,51,0|script|JackO#Ishi|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 11;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,71,61,0|script|JackO#Sandra|184
+003-1,71,61,0|script|JackO#Sandra|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 12;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
 
-003-1,136,35,0|script|JackO#Vincent|184
+003-1,136,35,0|script|JackO#Vincent|133
 {
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    set @JACKOID, 13;
+    callfunc "HocusCampaign";
+    if ($@HW2020_SLAIN[@JACKOID])
+        disablenpc strnpcinfo(0);
+    set @JACKOID, 0;
     close;
 }
+

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -285,7 +285,7 @@ OnInit:
 {
     end;
 OnTouch:
-    if ($@HW2020_HOCUS == 2)
+    if ($@HW2020_HOCUS == 2 || $@HW2020_HOCUS == 3)
         warp "070-1", 0, 0;
     end;
 }

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -25,6 +25,7 @@ L_Main:
     if ($DOOMSDAY_TJANDE || !$DOOMSDAY_TWARP)
         end;
 
+    /////////////////////////////////////////////////////////////////////////
     // Underworld Controller
 
     // TYPE 1141, SASQUATCH

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -112,3 +112,22 @@ OnDeath13:
     end;
 }
 
+
+// Return gate
+003-1,142,18,0|script|To Underworld|400,1,0
+{
+    end;
+OnTouch:
+    if ($DOOMSDAY != 3) end;
+    if ($DOOMSDAY_TJANDE == 1) end;
+    if (!$@halloween_time) end;
+
+    warp "070-1", 134, 30;
+    close;
+
+OnInit:
+    if ($DOOMSDAY != 3)
+        disablenpc "To Underworld";
+    end;
+}
+

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -29,42 +29,42 @@ L_Main:
 
     // TYPE 1141, SASQUATCH
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath1")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 20, 20, 75, 100, "", 1141, 30-$@UnderMc, "HW2020 Mobs::OnDeath1";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 20, 20, 75, 100, "", 1141, 20-$@UnderMc, "HW2020 Mobs::OnDeath1";
 
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath2")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 77, 20, 127, 100, "", 1141, 30-$@UnderMc, "HW2020 Mobs::OnDeath2";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 77, 20, 127, 100, "", 1141, 20-$@UnderMc, "HW2020 Mobs::OnDeath2";
 
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath3")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 130, 20, 170, 100, "", 1141, 30-$@UnderMc, "HW2020 Mobs::OnDeath3";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 130, 20, 170, 100, "", 1141, 20-$@UnderMc, "HW2020 Mobs::OnDeath3";
 
     // TYPE 1140, TENGU
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath4")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 20, 20, 75, 100, "", 1140, 30-$@UnderMc, "HW2020 Mobs::OnDeath4";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 20, 20, 75, 100, "", 1140, 20-$@UnderMc, "HW2020 Mobs::OnDeath4";
 
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath5")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 77, 20, 127, 100, "", 1140, 30-$@UnderMc, "HW2020 Mobs::OnDeath5";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 77, 20, 127, 100, "", 1140, 20-$@UnderMc, "HW2020 Mobs::OnDeath5";
 
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath6")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 130, 20, 170, 100, "", 1140, 30-$@UnderMc, "HW2020 Mobs::OnDeath6";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 130, 20, 170, 100, "", 1140, 20-$@UnderMc, "HW2020 Mobs::OnDeath6";
 
     // TYPE 1143, SLAYER
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath7")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 20, 20, 75, 100, "", 1143, 30-$@UnderMc, "HW2020 Mobs::OnDeath7";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 20, 20, 75, 100, "", 1143, 20-$@UnderMc, "HW2020 Mobs::OnDeath7";
 
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath8")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 77, 20, 127, 100, "", 1143, 30-$@UnderMc, "HW2020 Mobs::OnDeath8";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 77, 20, 127, 100, "", 1143, 20-$@UnderMc, "HW2020 Mobs::OnDeath8";
 
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath9")+1;
-    if ($@UnderMc < 30)
-        areamonster "070-1", 130, 20, 170, 100, "", 1143, 30-$@UnderMc, "HW2020 Mobs::OnDeath9";
+    if ($@UnderMc < 20)
+        areamonster "070-1", 130, 20, 170, 100, "", 1143, 20-$@UnderMc, "HW2020 Mobs::OnDeath9";
 
     // GUARDIANS
     set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath10")+1;

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -6,4 +6,109 @@
 // Operates: 057-1 070-1 003-1
 // See also: npc/annuals/halloween/munro.txt
 
+// Monster Script Control
+-|script|HW2020 Mobs|32767
+{
+    close;
+
+OnInit:
+    goto L_Main;
+
+// They'll respawn at midday.
+OnClock1200:
+    goto L_Main;
+
+L_Main:
+    // Do not waste RAM/CPU if we don't need it
+    if ($DOOMSDAY != 3 || !$@halloween_time)
+        end;
+    if ($DOOMSDAY_TJANDE || !$DOOMSDAY_TWARP)
+        end;
+
+    // Underworld Controller
+
+    // TYPE 1141, SASQUATCH
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath1")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 20, 20, 75, 100, "", 1141, 30-$@UnderMc, "HW2020 Mobs::OnDeath1";
+
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath2")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 77, 20, 127, 100, "", 1141, 30-$@UnderMc, "HW2020 Mobs::OnDeath2";
+
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath3")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 130, 20, 170, 100, "", 1141, 30-$@UnderMc, "HW2020 Mobs::OnDeath3";
+
+    // TYPE 1140, TENGU
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath4")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 20, 20, 75, 100, "", 1140, 30-$@UnderMc, "HW2020 Mobs::OnDeath4";
+
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath5")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 77, 20, 127, 100, "", 1140, 30-$@UnderMc, "HW2020 Mobs::OnDeath5";
+
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath6")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 130, 20, 170, 100, "", 1140, 30-$@UnderMc, "HW2020 Mobs::OnDeath6";
+
+    // TYPE 1143, SLAYER
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath7")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 20, 20, 75, 100, "", 1143, 30-$@UnderMc, "HW2020 Mobs::OnDeath7";
+
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath8")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 77, 20, 127, 100, "", 1143, 30-$@UnderMc, "HW2020 Mobs::OnDeath8";
+
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath9")+1;
+    if ($@UnderMc < 30)
+        areamonster "070-1", 130, 20, 170, 100, "", 1143, 30-$@UnderMc, "HW2020 Mobs::OnDeath9";
+
+    // GUARDIANS
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath10")+1;
+    if ($@UnderMc < 3)
+        areamonster "070-1", 132, 30, 140, 36, "", 1147, 3-$@UnderMc, "HW2020 Mobs::OnDeath10";
+
+    set $@UnderMc, mobcount("070-1", "HW2020 Mobs::OnDeath11")+1;
+    if ($@UnderMc < 1)
+        areamonster "070-1", 134, 32, 135, 34, "", 1146, 1, "HW2020 Mobs::OnDeath10";
+
+    /////////////////////////////////////////////////////////////////////////
+    // Tulimshar Controller
+
+    // Done
+    set $@UnderMc, 0;
+    set $@TulimMc, 0;
+    end;
+
+// Labels
+OnDeath1:
+    end;
+OnDeath2:
+    end;
+OnDeath3:
+    end;
+OnDeath4:
+    end;
+OnDeath5:
+    end;
+OnDeath6:
+    end;
+OnDeath7:
+    end;
+OnDeath8:
+    end;
+OnDeath9:
+    end;
+OnDeath10:
+    end;
+OnDeath11:
+    end;
+OnDeath12:
+    end;
+OnDeath13:
+    end;
+}
 

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -368,6 +368,7 @@ L_NotReady:
 
 L_Finish:
     set $@HW2020_HOCUS, 3;
+    announce "Doomsday : Jande has been rescued from the Underworld." , 0;
     mapannounce "003-1", "The Lost : To be defeated... You should all get lost here forever..." , 0;
     areatimer 0, "003-1", 18, 18, 66, 62, 2000, "HW2020 Mobs::OnReward";
     end;

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -84,6 +84,8 @@ L_Main:
     end;
 
 // Labels
+OnDeath0:
+    end;
 OnDeath1:
     end;
 OnDeath2:
@@ -107,8 +109,6 @@ OnDeath10:
 OnDeath11:
     end;
 OnDeath12:
-    end;
-OnDeath13:
     end;
 }
 
@@ -162,6 +162,8 @@ function|script|HocusCampaign
     if (@JACKOID < 1)
         goto L_Return;
 
+    set @JACKOID, @JACKOID-1;
+
     if ($@HW2020_TIMER[@JACKOID] > gettimetick(2))
         goto L_Check;
 
@@ -185,7 +187,6 @@ function|script|HocusCampaign
         "Not now!", L_Abort;
 
 L_Begin:
-    set @JACKOID, @JACKOID-1;
     if ($@HW2020_TIMER[@JACKOID] > gettimetick(2))
         goto L_Return;
 
@@ -211,18 +212,18 @@ L_Begin:
     if (@JACKOID % 8 == 7)
         set @mobID, 1124; // Wight
 
-    // Define mob amound
-        set @mobAM, 8; // Zombie
+    // Define mob amount
+    set @mobAM, 8; // Default
     if (@JACKOID % 8 == 0)
         set @mobAM, 12; // Soul Snake must be more
     if (@JACKOID % 8 >= 4)
         set @mobAM, 6; // Stalker, JackO, Red and Wigh must be less
 
     // Spawn the Monsters
-    areamonster "003-1", getx()-10, gety()-10, getx()+10, gety()+10, "", @mobID, @mobAM, "HW2020 Mobs::OnDeath"+(@JACKOID+1);
+    areamonster "003-1", getx()-10, gety()-10, getx()+10, gety()+10, "", @mobID, @mobAM, "HW2020 Mobs::OnDeath"+@JACKOID;
 
     // Announce
-     mapannounce "003-1", "JackO : Hohoho... You cannot defeat me1" , 0;
+     mapannounce "003-1", "JackO : Hohoho... You cannot defeat meeeee!" , 0;
 
     // Clear temporary variables
     set @mobID, 0;
@@ -236,7 +237,7 @@ L_Abort:
 
 L_Check:
     // Count Monsters
-    set @TulimMc, mobcount("003-1", "HW2020 Mobs::OnDeath"+(@JACKOID+1))+1;
+    set @TulimMc, mobcount("003-1", "HW2020 Mobs::OnDeath"+@JACKOID)+1;
     if (@TulimMc)
         goto L_Information;
 
@@ -249,7 +250,8 @@ L_Check:
     return;
 
 L_Information:
-    message strcharinfo(0), "JackO : Hohoho... Still "+@TulimMC+" monsters alive... Defeat meeeeee.....!";
+    message strcharinfo(0), "JackO : Hohoho... Still "+@TulimMc+" monsters alive... Defeat meeeeee.....!";
+    set @TulimMc, 0;
     return;
 
 L_Return:

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -226,7 +226,7 @@ OnReward:
     next;
     mes ".:: DOOMSDAY ACT 5: THE FINAL BATTLE ::.";
     mes "---- ----";
-    mes "INTERLUDE 4: RESCUING JANDE";
+    mes "INTERLUDE III: RESCUING JANDE";
     mes "";
     mes "Continues in ##BOctober 24th, 17:30 UTC##b";
     mes "##1The Final Snapshot will happen at October 31st.##0";

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -132,3 +132,74 @@ OnInit:
     end;
 }
 
+003-1,44,40,0|script|#HW2020Bazar|424,0,0
+{
+    close;
+}
+
+////////////////////////////////////////////////
+// JackOs (13 JackOs)
+003-1,26,73,0|script|JackO#Tybalt|184
+{
+    close;
+}
+
+003-1,101,31,0|script|JackO#Nicolas|184
+{
+    close;
+}
+
+003-1,38,66,0|script|JackO#Elanore|184
+{
+    close;
+}
+
+003-1,56,70,0|script|JackO#Aisha|184
+{
+    close;
+}
+
+003-1,119,33,0|script|JackO#Nina|184
+{
+    close;
+}
+
+003-1,32,30,0|script|JackO#Ian|184
+{
+    close;
+}
+
+003-1,113,43,0|script|JackO#Luca|184
+{
+    close;
+}
+
+003-1,47,79,0|script|JackO#Ekinu|184
+{
+    close;
+}
+
+003-1,38,79,0|script|JackO#Ryan|184
+{
+    close;
+}
+
+003-1,53,45,0|script|JackO#Neko|184
+{
+    close;
+}
+
+003-1,54,51,0|script|JackO#Ishi|184
+{
+    close;
+}
+
+003-1,71,61,0|script|JackO#Sandra|184
+{
+    close;
+}
+
+003-1,136,35,0|script|JackO#Vincent|184
+{
+    close;
+}

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -265,7 +265,7 @@ function|script|HocusCampaign
     mes "2. Talk to JackO after this to lift the curse";
     mes "3. Once all 13 NPCs curse is lifted, go to ?????";
     mes "";
-    mes "##1Time Limit: 1 hour since first JackO monster spawn.";
+    mes "##1Time Limit: 30 minutes since first JackO monster spawn.";
     next;
     menu
         "Bring it on!", L_Begin,
@@ -277,7 +277,7 @@ L_Begin:
 
     // Assign timer, set JackO to ACTIVE
     set $@HW2020_SLAIN[@JACKOID], 0;
-    set $@HW2020_TIMER[@JACKOID], gettimetick(2)+3600;
+    set $@HW2020_TIMER[@JACKOID], gettimetick(2)+1800;
 
     // Define mob id
     if (@JACKOID % 8 == 0)

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -1,7 +1,7 @@
 // Evol script
 // Year: 2020
 //
-// Controls Doomsday Event - Vanilla Jande's Rescue
+// Controls Doomsday Event - Vanilla Jande's Rescue (Halloween 2020)
 //
 // Operates: 057-1 070-1 003-1
 // See also: npc/annuals/halloween/munro.txt

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -232,27 +232,21 @@ OnReward:
     mes "##1The Final Snapshot will happen at October 31st.##0";
     next;
     // Reward
-    set @rand, rand(10);
+    set @rand, rand(7);
     if (@rand == 0)
         getitem "Eyepatch", 1; // Classic from HW and Christmas (10% chance)
     if (@rand == 1)
         getitem "MoubooHead", 1; // Replaced from: Circlet
     if (@rand == 2)
-        getitem "Bucket", 1;
-    if (@rand == 3)
         getitem "Goggles", 1;
-    if (@rand == 4)
+    if (@rand == 3)
         getitem "LeatherGoggles", 1;
-    if (@rand == 5)
+    if (@rand == 4)
         getitem "SailorHat", 1; // Replaced from: Pirate Hat (Rarity)
-    if (@rand == 6)
-        getitem "ToySabre", 1;
-    if (@rand == 7)
+    if (@rand == 5)
         getitem "SkullMask", 1;
-    if (@rand == 8)
+    if (@rand == 6)
         getitem "FaceMask", 1; // Actually Christmas
-    if (@rand == 9)
-        getitem "PaperBag", 1; // Actually Easter
     warp "009-1", 52, 40;
     message strcharinfo(0), "Numa : Thanks for helping. I know it is not much, but here is a reward for you.";
     close;

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -675,3 +675,40 @@ L_Return:
     close;
 }
 
+057-1,126,63,0|script|#HW2020Shroom|400
+{
+    // Halloween only
+    if (!$@halloween_time) end;
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    mes "This is a strange mushroom.";
+    mes "Seeing it makes you feel like saying";
+    mes "##B" + get(.invocation$, "alonsialonso") + "##b";
+    next;
+    mes "This never happened before. Must be halloween.";
+    mes "I should be careful, it could be related to [@@666|@@]!";
+    next;
+    mes "##9HINT: Use the spell only in the precise area of interest.##0";
+    mes "##9Side effects of spell misuse includes and are not limited to:##0";
+    mes "##9death, warp, heal and/or item loss.##0";
+    mes "";
+    mes "##9The spell will cease to function once Halloween is over.##0";
+    close;
+}
+
+070-1,134,30,0|script|#HW2020Chapel|400
+{
+    // Halloween only
+    if (!$@halloween_time) end;
+    callfunc "PCtoNPCRange";
+    if(@npc_check) end;
+    mes "Past this door lies the crypt where Tormenta was supposed to be.";
+    mes "I really should not lock myself up in a place where I cannot leave.";
+    next;
+    mes "It should be safe to try the following on the door:";
+    mes "##B" + get(.invocation$, "alonsialonso") + "##b";
+    // NOTE: This door should lead to 070-3, Abyss/Reaper Room.
+    // Players from TMW Hardcore would know.
+    close;
+}
+

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -9,10 +9,11 @@
 //  $@HW2020_SLAIN, array
 //  $@HW2020_TIMER, array
 //  $@HW2020_HOCUS, integer
-//  (0 - Not yet, 1 - Cutscene, 2 - Ambushed, 3 - Completed)
+//  (0 - Not yet, 1 - Cutscene, 2 - Ambushed, 3 - Completing, 4 - Completed)
 //  $@HW2020_CNT, temporary int
 //  $@JACKOID, temporary int
 //  $@UnderMc, temporary int
+//  @TulimMc, temporary int
 //  @JACKOID, temporary int
 //  @mobID, temporary int
 //  @mobAM, temporary int
@@ -205,6 +206,7 @@ OnTimer30000:
 L_Active:
     mapannounce "003-1", "##1There is a loud sound coming from the Bazar.##0" , 0;
     enablenpc "#HW2020Bazar";
+    stopnpctimer;
     end;
 }
 
@@ -250,6 +252,8 @@ OnTouch:
         end;
     if ($@HW2020_HOCUS == 2)
         goto L_Check;
+    if ($@HW2020_HOCUS == 3)
+        end;
     warp "009-1", 52, 40;
     end;
 
@@ -284,7 +288,39 @@ OnAmbush2:
     end;
 
 L_Check:
-    // TODO
+    set @TulimMc, mobcount("003-1", "HW2020 Mobs::OnDeath1")+1;
+    if (@TulimMc)
+        goto L_Reaper;
+
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath2")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath3")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath4")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath5")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath6")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath7")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath8")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath9")+1;
+    set @TulimMc, @TulimMc+mobcount("003-1", "HW2020 Mobs::OnDeath10")+1;
+
+    if (@TulimMc)
+        goto L_NotReady;
+
+    goto L_Finish;
+
+L_Reaper:
+    message strcharinfo(0), "The Lost : Hahaha! Don't you think I can't see you!";
+    set @TulimMc, 0;
+    end;
+
+L_NotReady:
+    message strcharinfo(0), strcharinfo(0) + " : I can still count "+@TulimMc+" monsters which need to be defeated first.";
+    set @TulimMc, 0;
+    end;
+
+L_Finish:
+    set $@HW2020_HOCUS, 3;
+    mapannounce "003-1", "The Lost : To be defeated... You should all get lost here forever..." , 0;
+    areatimer 0, "003-1", 15, 15, 66, 62, 5000, "#HW2020Bazar::OnReward";
     end;
 
 OnStopThere:
@@ -294,6 +330,7 @@ OnStopThere:
     end;
 
 OnReward:
+    set $@HW2020_HOCUS, 4;
     mes "[Jande]";
     mes "Jande was rescued. Numa will take care of him until he recovers.";
     mes "He struggled for words, but the time he spent there did a number on him.";

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -6,6 +6,60 @@
 // Operates: 057-1 070-1 003-1
 // See also: npc/annuals/halloween/munro.txt
 
+////////////////////////////////////////////////
+// JackO Central Processing Core ($@JACKOID)
+function|script|HocusJackO
+{
+    if (!$@HW2020_SLAIN[$@JACKOID])
+        goto L_Return;
+
+    if ($@HW2020_TIMER[$@JACKOID] < gettimetick(2))
+        goto L_Expired;
+
+    // Count the JackO
+    set $@HW2020_CNT, $@HW2020_CNT+1;
+    set $@JACKOID, 0;
+    return;
+
+// Time expired!
+L_Expired:
+    set $@HW2020_SLAIN[$@JACKOID], 0;
+    // Re-enable the NPC
+    if ($@JACKOID == 0)
+        enablenpc "JackO#Tybalt";
+    if ($@JACKOID == 1)
+        enablenpc "JackO#Nicolas";
+    if ($@JACKOID == 2)
+        enablenpc "JackO#Elanore";
+    if ($@JACKOID == 3)
+        enablenpc "JackO#Aisha";
+    if ($@JACKOID == 4)
+        enablenpc "JackO#Nina";
+    if ($@JACKOID == 5)
+        enablenpc "JackO#Ian";
+    if ($@JACKOID == 6)
+        enablenpc "JackO#Luca";
+    if ($@JACKOID == 7)
+        enablenpc "JackO#Ekinu";
+    if ($@JACKOID == 8)
+        enablenpc "JackO#Ryan";
+    if ($@JACKOID == 9)
+        enablenpc "JackO#Neko";
+    if ($@JACKOID == 10)
+        enablenpc "JackO#Ishi";
+    if ($@JACKOID == 11)
+        enablenpc "JackO#Sandra";
+    if ($@JACKOID == 12)
+        enablenpc "JackO#Vincent";
+    set $@JACKOID, 0;
+    return;
+
+L_Return:
+    set $@JACKOID, 0;
+    return;
+}
+
+////////////////////////////////////////////////
 // Monster Script Control
 -|script|HW2020 Mobs|32767
 {
@@ -110,6 +164,37 @@ OnDeath11:
     end;
 OnDeath12:
     end;
+
+OnTimer30000:
+    // Check every JackO
+    set $@HW2020_CNT, 0;
+    set $@JACKOID, 0; callfunc "HocusJackO";
+    set $@JACKOID, 1; callfunc "HocusJackO";
+    set $@JACKOID, 2; callfunc "HocusJackO";
+    set $@JACKOID, 3; callfunc "HocusJackO";
+    set $@JACKOID, 4; callfunc "HocusJackO";
+    set $@JACKOID, 5; callfunc "HocusJackO";
+    set $@JACKOID, 6; callfunc "HocusJackO";
+    set $@JACKOID, 7; callfunc "HocusJackO";
+    set $@JACKOID, 8; callfunc "HocusJackO";
+    set $@JACKOID, 9; callfunc "HocusJackO";
+    set $@JACKOID, 10; callfunc "HocusJackO";
+    set $@JACKOID, 11; callfunc "HocusJackO";
+    set $@JACKOID, 12; callfunc "HocusJackO";
+
+    // Check if portal is to be active
+    if ($@HW2020_CNT >= 13)
+        goto L_Active;
+
+    // Janitor
+    set $@HW2020_CNT, 0;
+    initnpctimer;
+    end;
+
+L_Active:
+    mapannounce "003-1", "##1There is a loud sound coming from the Bazar.##0" , 0;
+    enablenpc "#HW2020Bazar";
+    end;
 }
 
 
@@ -178,7 +263,7 @@ function|script|HocusCampaign
     mes "##3.:: Mission Goals ::.##0";
     mes "1. Defeat all monsters spawned by JackO";
     mes "2. Talk to JackO after this to lift the curse";
-    mes "3. Once all 13 NPCs curse is lifted, go to the Bazar.";
+    mes "3. Once all 13 NPCs curse is lifted, go to ?????";
     mes "";
     mes "##1Time Limit: 1 hour since first JackO monster spawn.";
     next;
@@ -246,6 +331,7 @@ L_Check:
 
     mes "[JackO]";
     mes "Hohoho... We'll meet againnnnnnnn!";
+    donpcevent "HW2020 Mobs::OnTimer30000";
     close2;
     return;
 

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -208,6 +208,55 @@ L_Active:
     enablenpc "#HW2020Bazar";
     stopnpctimer;
     end;
+
+// Misc functions
+OnStopThere:
+    if (getx() > 66 || gety() > 62)
+        warp "003-1", 44, 61;
+    sendcollision "003-1", 1, 42, 62, 46, 64;
+    end;
+
+OnReward:
+    set $@HW2020_HOCUS, 4;
+    mes "[Jande]";
+    mes "Jande was rescued. Numa will take care of him until he recovers.";
+    mes "He struggled for words, but the time he spent there did a number on him.";
+    mes "";
+    mes "What Jande found out? Where is Zax De'Kagen?";
+    next;
+    mes ".:: DOOMSDAY ACT 5: THE FINAL BATTLE ::.";
+    mes "---- ----";
+    mes "INTERLUDE 4: RESCUING JANDE";
+    mes "";
+    mes "Continues in ##BOctober 24th, 17:30 UTC##b";
+    mes "##1The Final Snapshot will happen at October 31st.##0";
+    next;
+    // Reward
+    set @rand, rand(10);
+    if (@rand == 0)
+        getitem "Eyepatch", 1; // Classic from HW and Christmas (10% chance)
+    if (@rand == 1)
+        getitem "MoubooHead", 1; // Replaced from: Circlet
+    if (@rand == 2)
+        getitem "Bucket", 1;
+    if (@rand == 3)
+        getitem "Goggles", 1;
+    if (@rand == 4)
+        getitem "LeatherGoggles", 1;
+    if (@rand == 5)
+        getitem "SailorHat", 1; // Replaced from: Pirate Hat (Rarity)
+    if (@rand == 6)
+        getitem "ToySabre", 1;
+    if (@rand == 7)
+        getitem "SkullMask", 1;
+    if (@rand == 8)
+        getitem "FaceMask", 1; // Actually Christmas
+    if (@rand == 9)
+        getitem "PaperBag", 1; // Actually Easter
+    warp "009-1", 52, 40;
+    message strcharinfo(0), "Numa : Thanks for helping. I know it is not much, but here is a reward for you.";
+    close;
+
 }
 
 
@@ -275,16 +324,16 @@ OnAmbush2:
     monster "003-1", 44, 40, "", 1073, 1, "HW2020 Mobs::OnDeath1";
     areamonster "003-1", 20, 20, 60, 60, "", 1106, 12, "HW2020 Mobs::OnDeath2";
     // Collection of nearly every monster you saw thus far :>
-    areamonster "003-1", 20, 20, 60, 40, "", 1096, 8, "HW2020 Mobs::OnDeath3";
-    areamonster "003-1", 20, 20, 60, 40, "", 1036, 6, "HW2020 Mobs::OnDeath4";
-    areamonster "003-1", 20, 20, 60, 40, "", 1103, 6, "HW2020 Mobs::OnDeath5";
-    areamonster "003-1", 20, 20, 60, 40, "", 1045, 4, "HW2020 Mobs::OnDeath6";
-    areamonster "003-1", 20, 20, 60, 40, "", 1022, 2, "HW2020 Mobs::OnDeath7";
-    areamonster "003-1", 20, 20, 60, 40, "", 1075, 2, "HW2020 Mobs::OnDeath8";
+    areamonster "003-1", 20, 25, 60, 40, "", 1096, 8, "HW2020 Mobs::OnDeath3";
+    areamonster "003-1", 20, 25, 60, 40, "", 1036, 6, "HW2020 Mobs::OnDeath4";
+    areamonster "003-1", 20, 20, 60, 35, "", 1103, 6, "HW2020 Mobs::OnDeath5";
+    areamonster "003-1", 20, 20, 60, 35, "", 1045, 4, "HW2020 Mobs::OnDeath6";
+    areamonster "003-1", 20, 20, 60, 30, "", 1022, 2, "HW2020 Mobs::OnDeath7";
+    areamonster "003-1", 20, 20, 60, 30, "", 1075, 2, "HW2020 Mobs::OnDeath8";
     areamonster "003-1", 20, 20, 60, 40, "", 1074, 2, "HW2020 Mobs::OnDeath9";
     areamonster "003-1", 20, 20, 60, 40, "", 1124, 2, "HW2020 Mobs::OnDeath10";
     set $@HW2020_HOCUS, 2;
-    areatimer 0, "003-1", 15, 15, 150, 100, 10, "#HW2020Bazar::OnStopThere";
+    areatimer 0, "003-1", 18, 18, 150, 100, 10, "HW2020 Mobs::OnStopThere";
     end;
 
 L_Check:
@@ -320,55 +369,8 @@ L_NotReady:
 L_Finish:
     set $@HW2020_HOCUS, 3;
     mapannounce "003-1", "The Lost : To be defeated... You should all get lost here forever..." , 0;
-    areatimer 0, "003-1", 15, 15, 66, 62, 5000, "#HW2020Bazar::OnReward";
+    areatimer 0, "003-1", 18, 18, 66, 62, 2000, "HW2020 Mobs::OnReward";
     end;
-
-OnStopThere:
-    if (getx() > 66 || gety() > 62)
-        warp "003-1", 44, 61;
-    sendcollision "003-1", 1, 42, 62, 46, 64;
-    end;
-
-OnReward:
-    set $@HW2020_HOCUS, 4;
-    mes "[Jande]";
-    mes "Jande was rescued. Numa will take care of him until he recovers.";
-    mes "He struggled for words, but the time he spent there did a number on him.";
-    mes "";
-    mes "What Jande found out? Where is Zax De'Kagen?";
-    next;
-    mes ".:: DOOMSDAY ACT 5: THE FINAL BATTLE ::.";
-    mes "---- INTERLUDE 4 ----";
-    mes "RESCUING JANDE";
-    mes "";
-    mes "Continues in ##BOctober 24th, 17:30 UTC##b";
-    mes "##1The Final Snapshot will happen at October 31st.##0";
-    next;
-    // Reward
-    set @rand, rand(10);
-    if (@rand == 0)
-        getitem "Eyepatch", 1; // Classic from HW and Christmas (10% chance)
-    if (@rand == 1)
-        getitem "MoubooHead", 1; // Replaced from: Circlet
-    if (@rand == 2)
-        getitem "Bucket", 1;
-    if (@rand == 3)
-        getitem "Goggles", 1;
-    if (@rand == 4)
-        getitem "LeatherGoggles", 1;
-    if (@rand == 5)
-        getitem "SailorHat", 1; // Replaced from: Pirate Hat (Rarity)
-    if (@rand == 6)
-        getitem "ToySabre", 1;
-    if (@rand == 7)
-        getitem "SkullMask", 1;
-    if (@rand == 8)
-        getitem "FaceMask", 1; // Actually Christmas
-    if (@rand == 9)
-        getitem "PaperBag", 1; // Actually Easter
-    warp "009-1", 52, 40;
-    message strcharinfo(0), "Numa : Thanks for helping. I know it is not much, but here is a reward for you.";
-    close;
 
 OnInit:
     disablenpc "#HW2020Bazar";

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -1,0 +1,9 @@
+// Evol script
+// Year: 2020
+//
+// Controls Doomsday Event - Vanilla Jande's Rescue
+//
+// Operates: 057-1 070-1 003-1
+// See also: npc/annuals/halloween/munro.txt
+
+

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -383,8 +383,8 @@ OnTimer5000:
 L_Janitor:
     killmonster "003-1", "All";
     set $@HW2020_HOCUS, 0;
-    cleararray $@HW2020_SLAIN;
-    cleararray $@HW2020_TIMER;
+    cleararray $@HW2020_SLAIN, 0, 20;
+    cleararray $@HW2020_TIMER, 0, 20;
     enablenpc "JackO#Tybalt";
     enablenpc "JackO#Nicolas";
     enablenpc "JackO#Elanore";

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -8,7 +8,7 @@
 // Variables:
 //  $@HW2020_SLAIN, array
 //  $@HW2020_TIMER, array
-//  $@HW2020_HOCUS, integer
+//  $@HW2020_HOCUS, integer (0 - Not yet, 1 - Ambushed, 2 - Completed)
 //  $@HW2020_CNT, temporary int
 //  $@JACKOID, temporary int
 //  $@UnderMc, temporary int
@@ -208,6 +208,7 @@ L_Active:
 }
 
 
+////////////////////////////////////////////////
 // Return gate
 003-1,142,18,0|script|To Underworld|400,1,0
 {
@@ -226,15 +227,67 @@ OnInit:
     end;
 }
 
+
+////////////////////////////////////////////////
 003-1,44,40,0|script|#HW2020Bazar|424,0,0
 {
     close;
 
 OnTouch:
-
-    // BOSS: 1073 The Lost
-
+    if ($@HW2020_HOCUS == 0)
+        goto L_Ambush;
+    if ($@HW2020_HOCUS == 1)
+        goto L_Check;
+    warp "009-1", 52, 40;
     end;
+
+L_Ambush:
+    // TODO
+    end;
+
+L_Check:
+    // TODO
+    end;
+
+OnReward:
+    mes "[Jande]";
+    mes "Jande was rescued. Numa will take care of him until he recovers.";
+    mes "He struggled for words, but the time he spent there did a number on him.";
+    mes "";
+    mes "What Jande found out? Where is Zax De'Kagen?";
+    next;
+    mes ".:: DOOMSDAY ACT 5: THE FINAL BATTLE ::.";
+    mes "---- INTERLUDE 4 ----";
+    mes "RESCUING JANDE";
+    mes "";
+    mes "Continues in ##BOctober 24th, 17:30 UTC##b";
+    mes "##1The Final Snapshot will happen at October 31st.##0";
+    next;
+    // Reward
+    set @rand, rand(10);
+    if (@rand == 0)
+        getitem "Eyepatch", 1; // Classic from HW and Christmas (10% chance)
+    if (@rand == 1)
+        getitem "MoubooHead", 1; // Replaced from: Circlet
+    if (@rand == 2)
+        getitem "Bucket", 1;
+    if (@rand == 3)
+        getitem "Goggles", 1;
+    if (@rand == 4)
+        getitem "LeatherGoggles", 1;
+    if (@rand == 5)
+        getitem "SailorHat", 1; // Replaced from: Pirate Hat (Rarity)
+    if (@rand == 6)
+        getitem "ToySabre", 1;
+    if (@rand == 7)
+        getitem "SkullMask", 1;
+    if (@rand == 8)
+        getitem "FaceMask", 1; // Actually Christmas
+    if (@rand == 9)
+        getitem "PaperBag", 1; // Actually Easter
+    warp "009-1", 52, 40;
+    message strcharinfo(0), "Numa : Thanks for helping. I know it is not much, but here is a reward for you.";
+    close;
 
 OnInit:
     disablenpc "#HW2020Bazar";

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -8,7 +8,8 @@
 // Variables:
 //  $@HW2020_SLAIN, array
 //  $@HW2020_TIMER, array
-//  $@HW2020_HOCUS, integer (0 - Not yet, 1 - Ambushed, 2 - Completed)
+//  $@HW2020_HOCUS, integer
+//  (0 - Not yet, 1 - Cutscene, 2 - Ambushed, 3 - Completed)
 //  $@HW2020_CNT, temporary int
 //  $@JACKOID, temporary int
 //  $@UnderMc, temporary int
@@ -229,6 +230,15 @@ OnInit:
 
 
 ////////////////////////////////////////////////
+003-1,44,64,0|script|#HW2020ActionLess|400,3,0
+{
+    end;
+OnTouch:
+    if ($@HW2020_HOCUS == 2)
+        warp "070-1", 0, 0;
+    end;
+}
+
 003-1,44,40,0|script|#HW2020Bazar|424,0,0
 {
     close;
@@ -237,16 +247,50 @@ OnTouch:
     if ($@HW2020_HOCUS == 0)
         goto L_Ambush;
     if ($@HW2020_HOCUS == 1)
+        end;
+    if ($@HW2020_HOCUS == 2)
         goto L_Check;
     warp "009-1", 52, 40;
     end;
 
+// TODO
 L_Ambush:
-    // TODO
+    set $@HW2020_HOCUS, 1;
+    mapannounce "003-1", "What, did you thought it would be so easy?" , 0;
+    addnpctimer 3000, "#HW2020Bazar::OnAmbush1";
+    end;
+
+OnAmbush1:
+    mapannounce "003-1", "Hahaha! I am the self-proclaimed sovereign of the underworld..." , 0;
+    addnpctimer 3000, "#HW2020Bazar::OnAmbush2";
+    end;
+
+OnAmbush2:
+    mapannounce "003-1", "...THE LOST! Return to where you come from!!" , 0;
+    // Boss and his shrooms
+    monster "003-1", 44, 40, "", 1073, 1, "HW2020 Mobs::OnDeath1";
+    areamonster "003-1", 20, 20, 60, 60, "", 1106, 12, "HW2020 Mobs::OnDeath2";
+    // Collection of nearly every monster you saw thus far :>
+    areamonster "003-1", 20, 20, 60, 40, "", 1096, 8, "HW2020 Mobs::OnDeath3";
+    areamonster "003-1", 20, 20, 60, 40, "", 1036, 6, "HW2020 Mobs::OnDeath4";
+    areamonster "003-1", 20, 20, 60, 40, "", 1103, 6, "HW2020 Mobs::OnDeath5";
+    areamonster "003-1", 20, 20, 60, 40, "", 1045, 4, "HW2020 Mobs::OnDeath6";
+    areamonster "003-1", 20, 20, 60, 40, "", 1022, 2, "HW2020 Mobs::OnDeath7";
+    areamonster "003-1", 20, 20, 60, 40, "", 1075, 2, "HW2020 Mobs::OnDeath8";
+    areamonster "003-1", 20, 20, 60, 40, "", 1074, 2, "HW2020 Mobs::OnDeath9";
+    areamonster "003-1", 20, 20, 60, 40, "", 1124, 2, "HW2020 Mobs::OnDeath10";
+    set $@HW2020_HOCUS, 2;
+    areatimer 0, "003-1", 15, 15, 150, 100, 10, "#HW2020Bazar::OnStopThere";
     end;
 
 L_Check:
     // TODO
+    end;
+
+OnStopThere:
+    if (getx() > 66 || gety() > 62)
+        warp "003-1", 44, 61;
+    sendcollision "003-1", 1, 42, 62, 46, 64;
     end;
 
 OnReward:

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -5,6 +5,16 @@
 //
 // Operates: 057-1 070-1 003-1
 // See also: npc/annuals/halloween/munro.txt
+// Variables:
+//  $@HW2020_SLAIN, array
+//  $@HW2020_TIMER, array
+//  $@HW2020_HOCUS, integer
+//  $@HW2020_CNT, temporary int
+//  $@JACKOID, temporary int
+//  $@UnderMc, temporary int
+//  @JACKOID, temporary int
+//  @mobID, temporary int
+//  @mobAM, temporary int
 
 ////////////////////////////////////////////////
 // JackO Central Processing Core ($@JACKOID)

--- a/world/map/npc/annuals/halloween/doomsday.txt
+++ b/world/map/npc/annuals/halloween/doomsday.txt
@@ -334,6 +334,7 @@ OnAmbush2:
     areamonster "003-1", 20, 20, 60, 40, "", 1124, 2, "HW2020 Mobs::OnDeath10";
     set $@HW2020_HOCUS, 2;
     areatimer 0, "003-1", 18, 18, 150, 100, 10, "HW2020 Mobs::OnStopThere";
+    initnpctimer;
     end;
 
 L_Check:
@@ -371,10 +372,40 @@ L_Finish:
     announce "Doomsday : Jande has been rescued from the Underworld." , 0;
     mapannounce "003-1", "The Lost : To be defeated... You should all get lost here forever..." , 0;
     areatimer 0, "003-1", 18, 18, 66, 62, 2000, "HW2020 Mobs::OnReward";
+    stopnpctimer;
     end;
 
 OnInit:
     disablenpc "#HW2020Bazar";
+    end;
+
+// Players defeated? :(
+OnTimer5000:
+    if (getmapusers("003-1") < 1)
+        goto L_Janitor;
+    initnpctimer;
+    end;
+
+L_Janitor:
+    killmonster "003-1", "All";
+    set $@HW2020_HOCUS, 0;
+    cleararray $@HW2020_SLAIN;
+    cleararray $@HW2020_TIMER;
+    enablenpc "JackO#Tybalt";
+    enablenpc "JackO#Nicolas";
+    enablenpc "JackO#Elanore";
+    enablenpc "JackO#Aisha";
+    enablenpc "JackO#Nina";
+    enablenpc "JackO#Ian";
+    enablenpc "JackO#Luca";
+    enablenpc "JackO#Ekinu";
+    enablenpc "JackO#Ryan";
+    enablenpc "JackO#Neko";
+    enablenpc "JackO#Ishi";
+    enablenpc "JackO#Sandra";
+    enablenpc "JackO#Vincent";
+    disablenpc strnpcinfo(0);
+    stopnpctimer;
     end;
 }
 

--- a/world/map/npc/annuals/halloween/munro.txt
+++ b/world/map/npc/annuals/halloween/munro.txt
@@ -98,6 +98,19 @@ L_Tormenta:
 
     // Spawn Tormenta and finish
     monster "057-1", 126, 64, "Tormenta", 1137, 1, "Munro::OnTormentaDie";
+
+    // Doomsday Untils
+    if ($DOOMSDAY == 3)
+        goto L_Doomsday;
+    end;
+
+// Doomsday Act 5 Utils
+L_Doomsday:
+    if (!$DOOMSDAY_TWARP)
+        end;
+    if ($DOOMSDAY_TJANDE)
+        end;
+    set $DOOMSDAY_CNT2, $DOOMSDAY_CNT2+1;
     end;
 
 }

--- a/world/map/npc/functions/doomsday.txt
+++ b/world/map/npc/functions/doomsday.txt
@@ -248,6 +248,10 @@ OnJanitor:
     // Act 5: Cleanup
     if ($DOOMSDAY == 3 && !$DOOMSDAY_TWARP)
         donpcevent "Keshlam Maze::OnInit"; // Spawn monsters if needed
+    if ($DOOMSDAY != 3)
+        disablenpc "To Underworld";
+    if ($DOOMSDAY == 3)
+        enablenpc "To Underworld";
     // Clear timers
     setnpctimer 0;
     stopnpctimer;
@@ -1302,6 +1306,10 @@ function|script|DoomsdayAct5
         goto L_WaitRoom;
     if (getmap() == "099-1" || getmap() == "099-2" || getmap() == "099-3" || getmap() == "099-4" || getmap() == "099-6")
         goto L_WarpOut;
+    // Iilia, Candor, Botcheck, etc.
+    if (getmapflag(getmap(), MF_NOSAVE))
+        goto L_Return;
+    // Anywhere else is fine
     if (countitem("BlackRose") || @alonso)
         goto L_WarpTo;
     goto L_Return;
@@ -1312,12 +1320,12 @@ L_WarpTo:
         goto L_KeshlamMaze;
     if ($DOOMSDAY_TJANDE == 1)
         goto L_KeshlamAbandoned;
-    // Ops, nowhere to go, please stay dead
     if (!@alonso)
-        heal -100000, -10000;
+        message strcharinfo(0), "The Black Rose did a miracle! Failed to die!";
     else
-        set @alonso, 0;
-    return;
+        message strcharinfo(0), "World Shift : Shifted to full health";
+    // Ops, nowhere to go!
+    goto L_Payment;
 
 L_Payment:
     if (@alonso)
@@ -1331,7 +1339,8 @@ L_PayAlonso:
 
 L_PayNormal:
     delitem "BlackRose", 1;
-    getitem "DarkPetal", 1;
+    if (rand(5) < 3)
+        getitem "DarkPetal", 1;
     return;
 
 L_WarpOut:

--- a/world/map/npc/functions/doomsday.txt
+++ b/world/map/npc/functions/doomsday.txt
@@ -38,7 +38,7 @@ function|script|DoomsdayDebug
     mes "";
     mes "Act 5:";
     mes "Warp to fake Keshlam? "+if_then_else($DOOMSDAY_TWARP, "No", "Yes");
-    mes "Jande was rescued? "+if_then_else($DOOMSDAY_TJANDE, "No", "Yes");
+    mes "Jande was rescued? "+if_then_else($DOOMSDAY_TJANDE, "Yes", "No");
     mes "$DOOMSDAY_CNT2: "+$DOOMSDAY_CNT2;
     mes "Vanilla Mode? "+if_then_else($DOOMSDAY_VANILLA, "Yes", "No");
     //($DOOMSDAY_SUMMON ? "Yes" : "No");

--- a/world/map/npc/functions/doomsday.txt
+++ b/world/map/npc/functions/doomsday.txt
@@ -38,7 +38,8 @@ function|script|DoomsdayDebug
     mes "";
     mes "Act 5:";
     mes "Warp to fake Keshlam? "+if_then_else($DOOMSDAY_TWARP, "No", "Yes");
-    mes "Jande was rescued? "+if_then_else($DOOMSDAY_TJANDE, "Yes", "No");
+    mes "Jande was rescued? "+if_then_else($@HW2020_HOCUS > 2, "Yes", "No");
+    mes "Jande has recovered? "+if_then_else($DOOMSDAY_TJANDE, "Yes", "No");
     mes "$DOOMSDAY_CNT2: "+$DOOMSDAY_CNT2;
     mes "Vanilla Mode? "+if_then_else($DOOMSDAY_VANILLA, "Yes", "No");
     //($DOOMSDAY_SUMMON ? "Yes" : "No");

--- a/world/map/npc/functions/doomsday.txt
+++ b/world/map/npc/functions/doomsday.txt
@@ -38,6 +38,8 @@ function|script|DoomsdayDebug
     mes "";
     mes "Act 5:";
     mes "Warp to fake Keshlam? "+if_then_else($DOOMSDAY_TWARP, "No", "Yes");
+    mes "Jande was rescued? "+if_then_else($DOOMSDAY_TJANDE, "No", "Yes");
+    mes "$DOOMSDAY_CNT2: "+$DOOMSDAY_CNT2;
     mes "Vanilla Mode? "+if_then_else($DOOMSDAY_VANILLA, "Yes", "No");
     //($DOOMSDAY_SUMMON ? "Yes" : "No");
     next;
@@ -59,8 +61,9 @@ function|script|DoomsdayDebug
         "[2][4][3] Council - Blue Sage's Residence",L_NivalCouncil,
         "[2][4][4] Toggle Zealite Upgrade",L_Zealite,
         "[3][5][0] Keshlam Warps",L_Keshlam,
-        "[3][5][1] Kage's Final Battle",L_Kage,
-        "[3][5][2] Vanilla Mode",L_Vanilla,
+        "[3][5][1] Rescuing Jande",L_Jande,
+        "[3][5][2] Kage's Final Battle",L_Kage,
+        "[3][5][3] Vanilla Mode",L_Vanilla,
         "[-] Close",L_Close;
 
 L_Close:
@@ -183,10 +186,16 @@ L_Keshlam:
     gmlog strcharinfo(0) + " changed doomsday warp to Keshlam Maze";
     return;
 
-L_Kage:
+L_Jande:
     set $DOOMSDAY_TWARP, 1;
     donpcevent "Doomsday::OnJanitor"; // TODO
     gmlog strcharinfo(0) + " changed doomsday warp to Abandoned Building";
+    return;
+
+L_Kage:
+    set $DOOMSDAY_TJANDE, 1;
+    donpcevent "Doomsday::OnJanitor"; // TODO
+    gmlog strcharinfo(0) + " changed Jande from MIA to ACT. Final battle begun.";
     return;
 
 L_Vanilla:

--- a/world/map/npc/functions/doomsday.txt
+++ b/world/map/npc/functions/doomsday.txt
@@ -1313,7 +1313,10 @@ L_WarpTo:
     if ($DOOMSDAY_TJANDE == 1)
         goto L_KeshlamAbandoned;
     // Ops, nowhere to go, please stay dead
-    heal -100000, -10000;
+    if (!@alonso)
+        heal -100000, -10000;
+    else
+        set @alonso, 0;
     return;
 
 L_Payment:

--- a/world/map/npc/functions/doomsday.txt
+++ b/world/map/npc/functions/doomsday.txt
@@ -1302,18 +1302,33 @@ function|script|DoomsdayAct5
         goto L_WaitRoom;
     if (getmap() == "099-1" || getmap() == "099-2" || getmap() == "099-3" || getmap() == "099-4" || getmap() == "099-6")
         goto L_WarpOut;
-    if (countitem("BlackRose"))
+    if (countitem("BlackRose") || @alonso)
         goto L_WarpTo;
     goto L_Return;
 
 L_WarpTo:
-    delitem "BlackRose", 1;
-    getitem "DarkPetal", 1;
     heal 100000, 10000;
     if ($DOOMSDAY_TWARP == 0)
         goto L_KeshlamMaze;
-    else
+    if ($DOOMSDAY_TJANDE == 1)
         goto L_KeshlamAbandoned;
+    // Ops, nowhere to go, please stay dead
+    heal -100000, -10000;
+    return;
+
+L_Payment:
+    if (@alonso)
+        goto L_PayAlonso;
+    goto L_PayNormal;
+
+L_PayAlonso:
+    delitem "DarkPetal", 1;
+    set @alonso, 0;
+    return;
+
+L_PayNormal:
+    delitem "BlackRose", 1;
+    getitem "DarkPetal", 1;
     return;
 
 L_WarpOut:
@@ -1350,11 +1365,11 @@ L_KeshlamMaze:
         warp "099-8", 23, 378;
     else
         warp "099-8", 379, 378;
-    return;
+    goto L_Payment;
 
 L_KeshlamAbandoned:
     warp "099-1", 34, 34;
-    return;
+    goto L_Payment;
 }
 
 009-1,30,43,0|script|Chest#DarkRose|111

--- a/world/map/npc/magic/_import.txt
+++ b/world/map/npc/magic/_import.txt
@@ -43,5 +43,6 @@ npc: npc/magic/level2-make-short-tanktop.txt
 npc: npc/magic/level2-make-tanktop.txt
 npc: npc/magic/level2-make-shirt.txt
 npc: npc/magic/level3-necromancy.txt
+npc: npc/magic/event-alonsoalonsy.txt
 npc: npc/magic/event-summon-managuardian.txt
 npc: npc/magic/event-summon-manatyrant.txt

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -26,7 +26,7 @@
         goto L_TulimRule;
 
     // General rule: Simulate death
-    if (countitem("BlackPetal"))
+    if (countitem("DarkPetal"))
         goto L_EmulateDeath;
 
     message strcharinfo(0), "You cannot shift worlds at this time.";
@@ -109,7 +109,7 @@ OnChapelCross:
     getitem "DarkPetal", 1;
 
     // Warp you to Tulimshar MMVI
-    warp "003-1", 44, 94;
+    warp "003-1", 142, 22;
     message strcharinfo(0), "World Shift : Shifted to Tulimshar (Area MMVI)";
     misceffect FX_PENTAGRAM_BUILDUP, strcharinfo(0);
     end;
@@ -140,5 +140,4 @@ OnInit:
     registercmd .invocation$, strnpcinfo(0);
     end;
 }
-
 

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -14,16 +14,37 @@
     if ($DOOMSDAY != 3) end;
 
     // Rule 1: Mushroom Spot
-    // TODO
+    if (isin("057-1", 125, 62, 127, 64))
+        goto L_ShroomRule;
+
     // Rule 2: Underworld Chapel
-    // TODO
+    if (isin("070-1", 134, 30, 134, 30))
+        goto L_ChapelRule;
+
     // Rule 3: Tulimshar MMVI
-    // TODO
+    if (isin("003-1", 42, 92, 46, 95))
+        goto L_TulimRule;
 
     // General rule: Simulate death
     if (countitem("BlackPetal"))
         goto L_EmulateDeath;
 
+//////////////////////////////////////////////////////
+L_ShroomRule:
+    // TODO
+    end;
+
+//////////////////////////////////////////////////////
+L_ChapelRule:
+    // TODO
+    end;
+
+//////////////////////////////////////////////////////
+L_TulimRule:
+    // TODO
+    end;
+
+//////////////////////////////////////////////////////
 L_EmulateDeath:
     set @alonso, 1;
     callfunc "DoomsdayAct5";

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -53,14 +53,14 @@ L_ShroomCheck:
         mes "Status: "+if_then_else($DOOMSDAY_CNT2 < 150,
         "##1Insufficient##0", "##2Sufficient##0")+
         if_then_else(getskilllv(SKILL_MAGIC_DARK) > 1,
-        "("+($DOOMSDAY_CNT2*100/150)+" %%)", "");
+        " ("+($DOOMSDAY_CNT2*100/150)+" %)", "");
     else
         mes "Status: Unknown.";
     close;
 
 L_ShroomCross:
     if ($DOOMSDAY_CNT2 < 150)
-        heal -Hp, 0;
+        goto L_FailCross;
     if (Hp < 1)
         close;
 
@@ -128,6 +128,10 @@ L_EmulateDeath:
     end;
 
 L_Close:
+    close;
+
+L_FailCross:
+    warp "045-1", 105, 125;
     close;
 
 //////////////////////////////////////////////////////

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -1,0 +1,39 @@
+// #alonsialonso
+// Replacement of Easter 2010 spell
+// Known as "World Shift Spell"
+//
+// Variables:
+// @alonso -> Nods to DoomsdayAct5() that you'll pay in petals
+
+-|script|alonsialonso|32767
+{
+    if (call("magic_checks", 1)) end;
+    callfunc "magic_exp";
+
+    // Not during Act 5 of Doomsday
+    if ($DOOMSDAY != 3) end;
+
+    // Rule 1: Mushroom Spot
+    // TODO
+    // Rule 2: Underworld Chapel
+    // TODO
+    // Rule 3: Tulimshar MMVI
+    // TODO
+
+    // General rule: Simulate death
+    if (countitem("BlackPetal"))
+        goto L_EmulateDeath;
+
+L_EmulateDeath:
+    set @alonso, 1;
+    callfunc "DoomsdayAct5";
+    end;
+
+//////////////////////////////////////////////////////
+OnInit:
+    set .invocation$, chr(MAGIC_SYMBOL) + "alonsialonso"; // used in npcs that refer to this spell
+    registercmd .invocation$, strnpcinfo(0);
+    end;
+}
+
+

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -29,18 +29,24 @@
     if (countitem("BlackPetal"))
         goto L_EmulateDeath;
 
+    message strcharinfo(0), "You cannot shift worlds at this time.";
+    end;
+
 //////////////////////////////////////////////////////
 L_ShroomRule:
+    if ($DOOMSDAY_TJANDE == 1) end;
     // TODO
     end;
 
 //////////////////////////////////////////////////////
 L_ChapelRule:
+    if ($DOOMSDAY_TJANDE == 1) end;
     // TODO
     end;
 
 //////////////////////////////////////////////////////
 L_TulimRule:
+    if ($DOOMSDAY_TJANDE == 1) end;
     // TODO
     end;
 

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -35,18 +35,52 @@
 //////////////////////////////////////////////////////
 L_ShroomRule:
     if ($DOOMSDAY_TJANDE == 1) end;
+    if (!$@halloween_time) end;
+
+    mes ".:: Eternal Seals Gate ::.";
+    mes "";
+    mes "One of the many (?) passages leading to the Underworld.";
+    mes "During halloween, it is weakened enough to allow beings to cross.";
+    mes "Perhaps it could be widened?";
+    next;
+    menu
+        "Leave", L_Close,
+        "[Dark Magic] Check Status", L_ShroomCheck,
+        "[Dangerous] Try to cross", L_ShroomCross;
+
+L_Close:
+    close;
+
+L_ShroomCheck:
+    if (getskilllv(SKILL_MAGIC_DARK) > 0)
+        mes "Status: "+if_then_else($DOOMSDAY_CNT2 < 150,
+        "##1Insufficient##0", "##2Sufficient##0")+
+        if_then_else(getskilllv(SKILL_MAGIC_DARK) > 1,
+        "("+($DOOMSDAY_CNT2*100/150)+" %%)", "");
+    else
+        mes "Status: Unknown.";
+    close;
+
+L_ShroomCross:
+    if ($DOOMSDAY_CNT2 < 150)
+        heal -Hp, 0;
+    if (Hp < 1)
+        close;
+
     // TODO
-    end;
+    close;
 
 //////////////////////////////////////////////////////
 L_ChapelRule:
     if ($DOOMSDAY_TJANDE == 1) end;
+    if (!$@halloween_time) end;
     // TODO
     end;
 
 //////////////////////////////////////////////////////
 L_TulimRule:
     if ($DOOMSDAY_TJANDE == 1) end;
+    if (!$@halloween_time) end;
     // TODO
     end;
 

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -48,9 +48,6 @@ L_ShroomRule:
         "[Dark Magic] Check Status", L_ShroomCheck,
         "[Dangerous] Try to cross", L_ShroomCross;
 
-L_Close:
-    close;
-
 L_ShroomCheck:
     if (getskilllv(SKILL_MAGIC_DARK) > 0)
         mes "Status: "+if_then_else($DOOMSDAY_CNT2 < 150,
@@ -77,7 +74,44 @@ L_ShroomCross:
 L_ChapelRule:
     if ($DOOMSDAY_TJANDE == 1) end;
     if (!$@halloween_time) end;
-    // TODO
+
+    mes ".:: Eternal Seals Gate ::.";
+    mes "";
+    mes "This chapel is clearly unlocked.";
+    mes "The lock seems to have been removed ##BOn purpose, from the outside.##b";
+    mes "This is probably where Tormenta lives.";
+    next;
+    mes "##9Warning: This is the Underworld and it may defy common logic.";
+    mes "Are you ready?##0";
+    mes "##1Cost: 1x [@@666|@@]";
+    next;
+    menu
+        "Cancel", L_Close,
+        "Open the gate!", L_GateCheck;
+
+L_GateCheck:
+    if (!(countitem("BlackRose")))
+        close;
+
+    close2;
+    misceffect FX_PENTAGRAM_BUILDUP, strcharinfo(0);
+    addtimer 6000, "alonsialonso::OnChapelCross";
+    end;
+
+OnChapelCross:
+    if (Hp < 1)
+        end;
+    if (!(countitem("BlackRose")))
+        end;
+
+    // Payment Execution
+    delitem "BlackRose", 1;
+    getitem "DarkPetal", 1;
+
+    // Warp you to Tulimshar MMVI
+    warp "003-1", 44, 94;
+    message strcharinfo(0), "World Shift : Shifted to Tulimshar (Area MMVI)";
+    misceffect FX_PENTAGRAM_BUILDUP, strcharinfo(0);
     end;
 
 //////////////////////////////////////////////////////
@@ -92,6 +126,9 @@ L_EmulateDeath:
     set @alonso, 1;
     callfunc "DoomsdayAct5";
     end;
+
+L_Close:
+    close;
 
 //////////////////////////////////////////////////////
 OnInit:

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -34,8 +34,9 @@
 
 //////////////////////////////////////////////////////
 L_ShroomRule:
-    if ($DOOMSDAY_TJANDE == 1) end;
     if (!$@halloween_time) end;
+    if (!$DOOMSDAY_TWARP) end;
+    if ($DOOMSDAY_TJANDE == 1) end;
 
     mes ".:: Eternal Seals Gate ::.";
     mes "";
@@ -55,7 +56,7 @@ L_ShroomCheck:
         if_then_else(getskilllv(SKILL_MAGIC_DARK) > 1,
         " ("+($DOOMSDAY_CNT2*100/150)+" %)", "");
     else
-        mes "Status: Unknown.";
+        mes "Status: ##8Unknown##0";
     close;
 
 L_ShroomCross:

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -67,7 +67,10 @@ L_ShroomCross:
     if (Hp < 1)
         close;
 
-    // TODO
+    // Warp you to Underworld
+    warp "070-1", 30, 92;
+    message strcharinfo(0), "World Shift : Shifted to Underworld (Area 70)";
+    misceffect FX_PENTAGRAM_BUILDUP, strcharinfo(0);
     close;
 
 //////////////////////////////////////////////////////

--- a/world/map/npc/magic/event-alonsoalonsy.txt
+++ b/world/map/npc/magic/event-alonsoalonsy.txt
@@ -22,8 +22,8 @@
         goto L_ChapelRule;
 
     // Rule 3: Tulimshar MMVI
-    if (isin("003-1", 42, 92, 46, 95))
-        goto L_TulimRule;
+    //if (isin("003-1", 42, 92, 46, 95))
+    //    goto L_TulimRule;
 
     // General rule: Simulate death
     if (countitem("DarkPetal"))
@@ -113,13 +113,6 @@ OnChapelCross:
     warp "003-1", 142, 22;
     message strcharinfo(0), "World Shift : Shifted to Tulimshar (Area MMVI)";
     misceffect FX_PENTAGRAM_BUILDUP, strcharinfo(0);
-    end;
-
-//////////////////////////////////////////////////////
-L_TulimRule:
-    if ($DOOMSDAY_TJANDE == 1) end;
-    if (!$@halloween_time) end;
-    // TODO
     end;
 
 //////////////////////////////////////////////////////

--- a/world/map/npc/scripts.conf
+++ b/world/map/npc/scripts.conf
@@ -79,4 +79,5 @@ npc: npc/annuals/xmas/mobmanager.txt
 npc: npc/annuals/halloween/config.txt
 npc: npc/annuals/halloween/debug.txt
 npc: npc/annuals/halloween/munro.txt
+npc: npc/annuals/halloween/doomsday.txt
 npc: npc/annuals/halloween/trick_or_treat.txt


### PR DESCRIPTION
Contains Halloween 2020 Event: “Rescuing Jande”

References:
Doomsday Act 5 Interlude 3
Doomsday Act 5 Interlude 4

----
Contains a **Bug on Purpose** which is too annoying to fix.

**Bug on Purpose:** World Shift can shift you to full health during Halloween 2020
(Doomsday Act 5 + Keshlam Maze OK but Jande not recovered)

Also, Black Rose will ressurect you on spot at same conditions.

Maps without saving or special rules - like Keshlam incl. swamps, boss rooms, Iilia, Candor, botcheck etc. does NOT benefits from this annoying bug.

However, Tulimshar benefits from it. This means each Black Rose during The Lost fight is a free revive.

So let's call it a *feature* and be done with it.

----
### Rewards

The rewards are given _only once, globally_ - In other words, once someone rescues Jande, **rewards cannot be obtained anymore.**

Not only that, but if the player dies in the fight which ends this interlude - remember there is the Black Rose bug, so it also means running out of roses - they will NOT be able to obtain the reward.

if inventory is full, the reward will be forsaken forever.

Numa will reward players with, randomly, one of the following items, with equal probability between them (10%).

* Eyepatch
* Mouboo Head
  - Replacing the Circlet which became a JackO drop
* ~~Bucket~~
* Goggles
* Leather Goggles
* Sailor Hat
  - Replacing Pirate Hat which became a JackO drop
* ~~Toy Sabre~~
  - Item can also be bought for lots of GP so it might be the less valuable reward
* Skull Mask
* Face Mask
  - Actually a Christmas Item
* ~~Paper Bag~~
  - Actually an Easter item

----
TODO
* [x] Create dialog NPC at shroom explaining about #alonsialonso
* [x] Create dialog NPC at the chapel door. Suggest to use #alonsialonso instead of trying to enter in a prison