### PR TITLE
brawling item check for focused brawling skill

### DIFF
--- a/world/map/npc/items/brawling_item.txt
+++ b/world/map/npc/items/brawling_item.txt
@@ -4,10 +4,28 @@
 
 function|script|BrawlingItem
 {
+    cleararray @skilllist_name$[0], "", 8;
+    cleararray @skilllist_id[0], 0, 8;
+    cleararray @skilllist_count[0], 0, 8;
+    getactivatedpoolskilllist;
+
+    if (@skilllist_id[0] == SKILL_BRAWLING)
+        goto L_BrawlingItem_Check_Weapon;
+
+    message strcharinfo(0), "This item can only be equipped by an true brawler.";
+
+    goto L_BrawlingItem_UnequipLater;
+
+L_BrawlingItem_Check_Weapon:
+
     if (getequipid(equip_hand1) == -1)
         goto L_Return;
 
     message strcharinfo(0), "This item's curse does not allow it to be used with weapons equipped.";
+
+    goto L_BrawlingItem_UnequipLater;
+
+L_BrawlingItem_UnequipLater:
 
     // This is for debug
     if (getgmlevel() >= 60)

--- a/world/map/npc/items/brawling_item.txt
+++ b/world/map/npc/items/brawling_item.txt
@@ -15,7 +15,7 @@ function|script|BrawlingItem
         bonus bStr, 2;
         bonus bDex, 1;
         bonus bMaxHP, 10;
-        bonus bCritical, 1;
+        bonus bHit, 2;
         bonus bFlee, 1;
 
     goto L_BrawlingItem_Check_Weapon;

--- a/world/map/npc/items/brawling_item.txt
+++ b/world/map/npc/items/brawling_item.txt
@@ -9,12 +9,16 @@ function|script|BrawlingItem
     cleararray @skilllist_count[0], 0, 8;
     getactivatedpoolskilllist;
 
-    if (@skilllist_id[0] == SKILL_BRAWLING)
+    if (@skilllist_id[0] != SKILL_BRAWLING)
         goto L_BrawlingItem_Check_Weapon;
 
-    message strcharinfo(0), "This item can only be equipped by an true brawler.";
+        bonus bStr, 2;
+        bonus bDex, 1;
+        bonus bMaxHP, 10;
+        bonus bCritical, 1;
+        bonus bFlee, 1;
 
-    goto L_BrawlingItem_UnequipLater;
+    goto L_BrawlingItem_Check_Weapon;
 
 L_BrawlingItem_Check_Weapon:
 

--- a/world/map/npc/items/brawling_item.txt
+++ b/world/map/npc/items/brawling_item.txt
@@ -14,9 +14,6 @@ function|script|BrawlingItem
 
         bonus bStr, 2;
         bonus bDex, 1;
-        bonus bMaxHP, 10;
-        bonus bHit, 2;
-        bonus bFlee, 1;
 
     goto L_BrawlingItem_Check_Weapon;
 


### PR DESCRIPTION
On normal dex ranges assassin set with speed skill does more dps than brawling skill only on high dex brawling skill gets stronger again (62 dex). That will cause that many simply use speed skill with the set instead of brawling skill.

here some values with conc/iron pots:
str:99 agi:137=99+38 vit:86 int:1 dex:31=30+1 luk:75
brawling skill: 2586 dps
speed skill: 2760 dps
str:99 agi:137=99+38 vit:86 int:1 dex:100=99+1 luk:75
brawling skill: 3216 dps
speed skill: 2900 dps
