### PR TITLE
Update #upmarmu for functional use

### DIFF
--- a/world/map/npc/magic/level2-magic-knuckles.txt
+++ b/world/map/npc/magic/level2-magic-knuckles.txt
@@ -1,10 +1,11 @@
 -|script|magic-knuckles|32767
 {
-    if(call("magic_checks")) end;
+    if (call("magic_checks")) end;
     if (Sp < 20) end;
     if (getskilllv(SKILL_MAGIC) < .level) end;
     set .@level, getskilllv(.school);
     if (.@level < .level) end;
+    if (getequipid(equip_hand1) != -1 || getequipid(equip_hand2) != -1) end;
     if (.@level <= 3 && countitem("Beer") >= 1) delitem "Beer", 1;
     elif (.@level <= 3) end;
     set @_M_BLOCK, 1; // block casting, until the timer clears it
@@ -13,16 +14,18 @@
     set Sp, Sp - 20;
     misceffect FX_MAGIC_KNUCKLE_CAST, strcharinfo(0);
     setarray @upmarmuspell[0],
-        @spellpower,
-        ((@spellpower/10) + 10), // charges
-        (((200 - Agi) * 1300) / 200), // delay
-        Str; // do not allow to equip light armor, cast, and then switch to heavy armor to get bonus str
+        (BASE_ATK), // dmg
+        ((Dex/3) + 10), // charges
+        (sqrt(300 - (Agi * 2))+(5/2)), // delay
+        Agi, // dmg bonus
+        ((sqrt(BaseLevel + 9) + Str) * 2); // do not allow to equip light armor, cast, and then switch to heavy armor to get bonus str
     callfunc "magic_exp";
     goto L_FreeRecast;
 
 OnAttack:
+    if (getequipid(equip_hand1) != -1 || getequipid(equip_hand2) != -1) goto OnDischarge;
     if (target(BL_ID, @target_id, 22) != 22) goto L_FreeRecast; // 0x10 | 0x02 | 0x04
-    void call("melee_damage", @upmarmuspell[0], @target_id, (30 + rand((@upmarmuspell[3]*2) + 5)));
+    void call("elt_damage", @upmarmuspell[0], (@upmarmuspell[3] + @upmarmuspell[4]), ELT_WATER, ELT_FIRE, FX_NONE);
     set @upmarmuspell[1], @upmarmuspell[1] - 1;
     goto L_FreeRecast;
 
@@ -39,7 +42,7 @@ OnDischarge:
     end;
 
 OnSetRecast:
-    overrideattack @upmarmuspell[2], 1, ATTACK_ICON_GENERIC, OVERRIDE_KNUCKLES, strnpcinfo(0)+"::OnAttack", @upmarmuspell[1];
+    overrideattack (@upmarmuspell[2] * @upmarmuspell[2]), 1, ATTACK_ICON_GENERIC, OVERRIDE_KNUCKLES, strnpcinfo(0)+"::OnAttack", @upmarmuspell[1]; // delay neeeds to be squared
     end;
 
 OnInit:


### PR DESCRIPTION
The spell stacks with the Brawling Skill's bonus and with iron potions, but not with the Speed Skill or concentration potions. It also provides a magic attack, which means that accuracy is essentially 100%. From my tests (with about 100 STR and 130 AGI), DPS reaches just over 2600, though it is probably closer to 2700 or 2800 with full AGI and additional DEX. The spell would essentially replace the brawler's need for concentration potions, though it might be possible to achieve a potential DPS higher than this using concentration potions.