### PR TITLE
Extend upmarmu duration (to make the spell less expensive) and modify damage

### DIFF
--- a/world/map/npc/magic/level2-magic-knuckles.txt
+++ b/world/map/npc/magic/level2-magic-knuckles.txt
@@ -14,11 +14,11 @@
     set Sp, Sp - 20;
     misceffect FX_MAGIC_KNUCKLE_CAST, strcharinfo(0);
     setarray @upmarmuspell[0],
-        (BASE_ATK), // dmg
-        ((Dex/3) + 10), // charges
-        (sqrt(300 - (Agi * 2))+(5/2)), // delay
+        BASE_ATK, // dmg
+        ((@spellpower/10) + ((Dex * 8)/(sqrt(BaseLevel + 34)) + 20), // charges (you get more at lower levels)
+        (sqrt(300 - (Agi * 2)) + (5/2)), // delay
         Agi, // dmg bonus
-        ((sqrt(BaseLevel + 9) + Str) * 2); // do not allow to equip light armor, cast, and then switch to heavy armor to get bonus str
+        (((BaseLevel/5) + Str) * 2); // do not allow to equip light armor, cast, and then switch to heavy armor to get bonus str
     callfunc "magic_exp";
     goto L_FreeRecast;
 
@@ -42,7 +42,7 @@ OnDischarge:
     end;
 
 OnSetRecast:
-    overrideattack (@upmarmuspell[2] * @upmarmuspell[2]), 1, ATTACK_ICON_GENERIC, OVERRIDE_KNUCKLES, strnpcinfo(0)+"::OnAttack", @upmarmuspell[1]; // delay neeeds to be squared
+    overrideattack (@upmarmuspell[2] * @upmarmuspell[2]), 1, ATTACK_ICON_GENERIC, OVERRIDE_KNUCKLES, strnpcinfo(0)+"::OnAttack", @upmarmuspell[1]; // delay needs to be squared
     end;
 
 OnInit:


### PR DESCRIPTION
These changes make #upmarmu slightly less expensive and more likely that it will actually be used. Spellpower is re-integrated so that players have a reason to increase INT for more than just mana and mana regen and charges have been tweaked to make the spell more favourable for lower level players.