### PR TITLE
Change upmarmu damage bonus (NERF)

### DIFF
--- a/world/map/npc/magic/level2-magic-knuckles.txt
+++ b/world/map/npc/magic/level2-magic-knuckles.txt
@@ -17,7 +17,7 @@
         BASE_ATK, // dmg
         ((@spellpower/10) + ((Dex * 8)/(sqrt(BaseLevel + 34)) + 20)), // charges (you get more at lower levels)
         (sqrt(300 - (Agi * 2)) + (5/2)), // delay
-        Agi, // dmg bonus
+        ((max(Int, Agi) + max(Int, Str)) / 2), // dmg bonus
         (((BaseLevel/5) + Str) * 2); // do not allow to equip light armor, cast, and then switch to heavy armor to get bonus str
     callfunc "magic_exp";
     goto L_FreeRecast;


### PR DESCRIPTION
Instead of Agi, it'll now be: (Str + Agi) / 2

Therefore, strength is important.
However, if your int exceed any of these two attributes, it'll be used instead.
If you're a mage with too many points in int, the int will be your bonus.

(Hence, the use of max() function in the formula)