### PR TITLE
Chronos Fix

### DIFF
--- a/world/map/npc/099-7/chronos.txt
+++ b/world/map/npc/099-7/chronos.txt
@@ -29,9 +29,8 @@
     goto L_Close;
 
 L_GiveMedals:
-    // BUG, FIXME! 2 + 4 = 4 boss medals
     set #BOSS_MEDALS, #BOSS_MEDALS + @dif;
-    set #BOSS_MEDALS_AVAILABLE, @dif;
+    set #BOSS_MEDALS_AVAILABLE, #BOSS_MEDALS_AVAILABLE + @dif;
     mes "[Chronos]";
     mes "\"For your deeds, I shall bestow upon you " + @dif + " Boss Medals. Use them wisely, they are the results of your hard effort.";
     mes "Boss Medals are earned each " + .price + " boss points. They are account-bound and cannot be given to other players, not even other versions of you.";
@@ -165,12 +164,21 @@ L_rewards_choice:
     next;
     callfunc "ItemMenu$";
     if(@item$ == "") goto L_Close;
-    mes "";
 
+    mes "";
+    mes "\"You really want the " + @item_names$[@index] + "?\"";
+    menu
+        "No", L_Close,
+        "Yes", L_Yes;
+    // to prevent fast key pressers and clickers from doing an error put No first as it's the highlighted item then.
+    // but its not able to handle if someone moves the mouse on the wrong menu item and double clicks.
+ 
+L_Yes:
     getinventorylist;
     if ((checkweight(@item$, 1) == 0) || (@inventorylist_count == 100)) goto L_InvFull;
     if ($CHRONOS_STOCK < 1) goto L_Maxed;
 
+    mes "";
     mes "[Chronos]";
     mes "\"Here's your " + @item_names$[@index] + ", good bye.\"";
     wgm "=> Player `"+strcharinfo(0) + "` obtained the following item from Chronos: "+ @item_names$[@index];

--- a/world/map/npc/099-7/chronos.txt
+++ b/world/map/npc/099-7/chronos.txt
@@ -193,11 +193,13 @@ L_Yes:
 
 L_Maxed:
     set @cur_date, 0;
+    mes "";
     mes "[Chronos]";
     mes "\"I'm afraid I don't have anything now, please wait until my next travel, or complete the Tree of Knowledge quest for my amusement.\"";
     goto L_Close;
 
 L_InvFull:
+    mes "";
     mes "[Chronos]";
     mes "\"Your inventory is full come again when you have some free space, good bye.\"";
     goto L_Close;


### PR DESCRIPTION
fixed the line that screwed #BOSS_POINTS_AVAILABLE variable and added a final confirmation question to minimize false clicking / key pressing errors.